### PR TITLE
Removed gunicorn `reload` flag in production

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -5,4 +5,4 @@ cd django-backend
 ./manage.py migrate --noinput
 
 # Run application
-python wait_for_db.py && gunicorn --bind 0.0.0.0:8080 fecfiler.wsgi -w 9 -t 200 --reload
+python wait_for_db.py && gunicorn --bind 0.0.0.0:8080 fecfiler.wsgi -w 9 -t 200


### PR DESCRIPTION
Remove `reload` flag in production, Per https://docs.gunicorn.org/en/stable/settings.html#reload
>This setting is intended for development. It will cause workers to be restarted whenever application code changes.