### PR TITLE
Removed redundant pip install from web-api Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN pip3 install -r /opt/requirements.txt
 RUN mv /etc/localtime /etc/localtime.backup && ln -s /usr/share/zoneinfo/EST5EDT /etc/localtime
 
 RUN useradd nxgu --no-create-home --home /opt/nxg_fec && chown -R nxgu:nxgu /opt/nxg_fec
-user nxgu
+USER nxgu
 
 EXPOSE 8080
-ENTRYPOINT ["sh", "-c", "cp /opt/requirements.txt . && pip3 install -r requirements.txt && python wait_for_db.py && gunicorn --bind 0.0.0.0:8080 fecfiler.wsgi -w 10 -t 200 --reload"]
+ENTRYPOINT ["/bin/sh", "-c", "python wait_for_db.py && gunicorn --bind 0.0.0.0:8080 fecfiler.wsgi -w 10 -t 200 --reload"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,11 +21,9 @@ services:
 
 
   api:
-    # env_file: ../local.env
     build:
       context: './'
       dockerfile: './Dockerfile'
-    # command: python manage.py runserver 0.0.0.0:8080
     image: fecfile-api
     container_name: fecfile-api
     volumes:
@@ -41,4 +39,3 @@ services:
       - FECFILE_TEST_DB_NAME
       - DJANGO_SETTINGS_MODULE=fecfiler.settings.local
       - DJANGO_SECRET_KEY
-


### PR DESCRIPTION
The extra pip install called in the ENTRYPOINT of the Dockerfile was redundant with the RUN command run earlier in the file. Without the second pip call, copying the requirement.txt file to the django-backend directory is not necessary.