### PR TITLE
Updated Python version to 3.8, updated packages for security vulnerabilities

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
 
   dependency-check:
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.8
 
     steps:
       - checkout
@@ -50,7 +50,7 @@ jobs:
     # These next lines defines a Docker executors: https://circleci.com/docs/2.0/executor-types/
     # A list of available CircleCI Docker convenience images are available here: https://circleci.com/developer/images/image/cimg/python
     docker:
-      - image: cimg/python:3.7-node
+      - image: cimg/python:3.8-node
       - image: cimg/postgres:12.8
 
     steps:
@@ -163,7 +163,7 @@ jobs:
   deploy:
 
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.8
 
     steps:
       - checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7
+FROM python:3.8
 ENV PYTHONUNBUFFERED=1
 
 RUN mkdir /opt/nxg_fec

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ dateparser==0.7.0
 decorator==4.3.0
 dj-database-url==0.3.0
 dj-static==0.0.6
-Django==3.2.11
+Django==3.2.12
 django-admin-shortcuts==2.0.0
 django-appconf==1.0.5
 django-bootstrap3==11.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ asn1crypto==0.24.0
 backcall==0.1.0
 bcrypt==3.1.4
 boto==2.49.0
-boto3==1.9.40
-botocore==1.12.196
+boto3==1.21.11
+botocore==1.24.11
 certifi==2018.8.24
 cfenv==0.5.2
 cffi==1.15.0
@@ -60,10 +60,10 @@ pytz==2018.5
 pytzdata==2018.7
 PyYAML==4.2b1
 regex==2018.11.22
-requests==2.23.0
+requests==2.27.1
 requests-toolbelt==0.8.0
 retry==0.9.2
-s3transfer==0.1.13
+s3transfer==0.5.2
 simplegeneric==0.8.1
 simplejson==3.16.0
 six==1.14.0
@@ -72,7 +72,7 @@ static3==0.6.1
 traitlets==4.3.2
 tzlocal==1.5.1
 uritemplate==3.0.0
-urllib3==1.25.9
+urllib3==1.26.8
 wcwidth==0.1.7
 fuzzywuzzy==0.17.0
 python-levenshtein==0.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,8 +47,7 @@ pendulum==2.0.4
 pexpect==4.6.0
 pickleshare==0.7.4
 prompt-toolkit==2.0.9
-psycopg2==2.7.5
-psycopg2-binary==2.7.5
+psycopg2==2.9.3
 ptyprocess==0.6.0
 pycparser==2.18
 PyPDF2==1.26.0
@@ -76,7 +75,7 @@ urllib3==1.26.8
 wcwidth==0.1.7
 fuzzywuzzy==0.17.0
 python-levenshtein==0.12.2
-numpy==1.21.5
+numpy==1.22.2
 pandas==1.3.5
 pandas-schema==0.3.5
 django-otp==0.9.3

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.x
+python-3.8.x


### PR DESCRIPTION
Issue #59 

- Updated Python to 3.8
- Updated Django and other packages for security vulnerabilities (see #59)

More info on Numpy/Python compatibility: https://github.com/numpy/numpy/releases. The last numpy version that supports 3.7 (numpy [1.21.5](https://github.com/numpy/numpy/releases/tag/v1.21.5)) is still vulnerable.

**How to test**
- Download this branch, run the app
- Currently deployed to `dev` space, I tested with https://fecfile-web-app-dev.app.cloud.gov and things don't seem any more broken than before