### PR TITLE
[Merge after release cut] Updated test command to match documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,7 +109,7 @@ jobs:
       - run:
           name: Run tests
           # Use built-in Django test module
-          command: coverage run --source='.' --rcfile=.coveragerc manage.py test --keep
+          command: coverage run --source='.' --rcfile=.coveragerc manage.py test --keepdb
           working_directory: ~/project/django-backend/
 
       - run:


### PR DESCRIPTION
After researching/discussing with @toddlees, the `--keep` command seems to work, but `--keepdb` reflects what's in the documentation: https://docs.djangoproject.com/en/3.2/ref/django-admin/#cmdoption-test-keepdb