### PR TITLE
[Merge after release cut] Switched to using `DEMO_KEY` FEC API key for local development

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -5,10 +5,9 @@ configuration as follows:
 ```
 DATABASE_URL = "postgres://postgres:postgres@0.0.0.0/postgres"
 FECFILE_TEST_DB_NAME = "postgres"
-FECFILE_FEC_WEBSITE_API_KEY=
+FECFILE_FEC_WEBSITE_API_KEY="DEMO_KEY"
 ```
 Notes:
-* There is no default FECFILE_FEC_WEBSITE_API_KEY, you must obtain and set this yourself
 
 CircleCI will attempt to deploy commits made to specific branches:
 * branch __develop__ -> cloud.gov dev space

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,3 +39,4 @@ services:
       - FECFILE_TEST_DB_NAME
       - DJANGO_SETTINGS_MODULE=fecfiler.settings.local
       - DJANGO_SECRET_KEY
+      - FECFILE_FEC_WEBSITE_API_KEY=DEMO_KEY


### PR DESCRIPTION
Issue #68

The environment variable `FECFILE_FEC_WEBSITE_API_KEY` is required for tests to pass (this isn't great, I put in #64) so I updated the Dockerfile and CircleCI docs to use the `DEMO_KEY` API key (this is a working key) as the default for local development.