### PR TITLE
[Merge after release cut] makes delete readonly on contact serializer

### DIFF
--- a/django-backend/fecfiler/contacts/serializers.py
+++ b/django-backend/fecfiler/contacts/serializers.py
@@ -15,10 +15,10 @@ class ContactSerializer(serializers.ModelSerializer):
         """
 
         contact_value = dict(
-            COM='Committee',
-            IND='Individual',
-            ORG='Organization',
-            CAN='Candidate',
+            COM="Committee",
+            IND="Individual",
+            ORG="Organization",
+            CAN="Candidate",
         )
         schema_name = f"Contact_{contact_value[data.get('type', None)]}"
         validation_result = validate.validate(schema_name, data)
@@ -58,6 +58,12 @@ class ContactSerializer(serializers.ModelSerializer):
             "candidate_district",
             "telephone",
             "country",
+            "created",
+            "updated",
+        ]
+        read_only_fields = [
+            "id",
+            "deleted",
             "created",
             "updated",
         ]

--- a/django-backend/fecfiler/contacts/tests.py
+++ b/django-backend/fecfiler/contacts/tests.py
@@ -47,6 +47,15 @@ class ContactTestCase(TestCase):
         self.assertIsNotNone(invalid_serializer.errors["zip"])
         self.assertIsNotNone(invalid_serializer.errors["country"])
 
+    def test_read_only_fields(self):
+        update = self.valid_contact.__dict__.copy()
+        update["deleted"] = "2022-03-24T15:24:53.865149-04:00"
+        update["last_name"] = "Newlastname"
+        contact_serializer = ContactSerializer(self.valid_contact, data=update)
+        contact_serializer.is_valid()
+        self.assertEquals(contact_serializer.validated_data["last_name"], "Newlastname")
+        self.assertIsNone(contact_serializer.validated_data.get("deleted"))
+
     def test_save_and_delete(self):
         self.valid_contact.save()
         contact_from_db = Contact.objects.get(last_name="Last")


### PR DESCRIPTION
## Summary

- Issue number #78 

This prevents PUTs and POSTs to our API from writing to the deleted field which would cause unexpected behavior

## How to test

Attempt to POST a new contact and set `deleted` to a timestamp
![image](https://user-images.githubusercontent.com/97105825/159996479-5d2102eb-24bc-460d-bd36-5ad55a34d01a.png)
You will find that `deleted` has not been written to.  The fact that the contact comes back is further proof that `deleted` was not written to.

Attempt to PUT to (update) an existing contact an set it's `deleted` field
![image](https://user-images.githubusercontent.com/97105825/159996017-9b403ec6-7ae3-4b5a-9969-6f30cc9ddc0a.png)
You will find that `deleted` has not been written to.  The fact that the contact comes back is further proof that `deleted` was not written to.

- 
