### PR TITLE
Local Development Celery Worker Node And Redis

### DIFF
--- a/Worker_Dockerfile
+++ b/Worker_Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.8
+ENV PYTHONUNBUFFERED=1
+
+RUN mkdir /opt/nxg_fec
+WORKDIR /opt/nxg_fec
+ADD requirements.txt /opt
+RUN pip3 install -r /opt/requirements.txt
+
+RUN mv /etc/localtime /etc/localtime.backup && ln -s /usr/share/zoneinfo/EST5EDT /etc/localtime
+
+ENTRYPOINT ["/bin/sh", "-c", "celery -A fecfiler worker --loglevel=info"]

--- a/django-backend/fecfiler/__init__.py
+++ b/django-backend/fecfiler/__init__.py
@@ -1,10 +1,8 @@
 """Django App for FECFile API
 """
-
+from .celery import app as celery_app
 
 """ This will make sure the app is always imported when
 Django starts so that shared_task will use this app.
 """
-from .celery import app as celery_app
-
 __all__ = ("celery_app",)

--- a/django-backend/fecfiler/__init__.py
+++ b/django-backend/fecfiler/__init__.py
@@ -1,0 +1,10 @@
+"""Django App for FECFile API
+"""
+
+
+""" This will make sure the app is always imported when
+Django starts so that shared_task will use this app.
+"""
+from .celery import app as celery_app
+
+__all__ = ("celery_app",)

--- a/django-backend/fecfiler/celery.py
+++ b/django-backend/fecfiler/celery.py
@@ -1,0 +1,22 @@
+import os
+
+from celery import Celery
+
+# Set the default Django settings module for the 'celery' program.
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "fecfiler.settings")
+
+app = Celery("fecfiler")
+
+# Using a string here means the worker doesn't have to serialize
+# the configuration object to child processes.
+# - namespace='CELERY' means all celery-related configuration keys
+#   should have a `CELERY_` prefix.
+app.config_from_object("django.conf:settings", namespace="CELERY")
+
+# Load task modules from all registered Django apps.
+app.autodiscover_tasks()
+
+
+@app.task(bind=True)
+def debug_task(self):
+    print(f"Request: {self.request!r}")

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -189,3 +189,11 @@ LOGGING = {
         "": {"handlers": ["default"], "level": "INFO", "propagate": True},
     },
 }
+
+"""Celery configurations
+"""
+CELERY_BROKER_URL = "redis://practical_noether:6379"
+CELERY_RESULT_BACKEND = "redis://practical_noether:6379"
+CELERY_ACCEPT_CONTENT = ["application/json"]
+CELERY_RESULT_SERIALIZER = "json"
+CELERY_TASK_SERIALIZER = "json"

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -192,8 +192,8 @@ LOGGING = {
 
 """Celery configurations
 """
-CELERY_BROKER_URL = "redis://practical_noether:6379"
-CELERY_RESULT_BACKEND = "redis://practical_noether:6379"
+CELERY_BROKER_URL = os.environ.get("REDIS_URL")
+CELERY_RESULT_BACKEND = os.environ.get("REDIS_URL")
 CELERY_ACCEPT_CONTENT = ["application/json"]
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_TASK_SERIALIZER = "json"

--- a/django-backend/fecfiler/urls.py
+++ b/django-backend/fecfiler/urls.py
@@ -1,11 +1,22 @@
 from django.conf.urls import url, include
 from django.urls import path
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
 from rest_framework_jwt.views import obtain_jwt_token, refresh_jwt_token
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 from .authentication.authenticate_login import LogoutView
 
 BASE_V1_URL = r"^api/v1/"
+
+
+@api_view(["GET"])
+def test_celery(request):
+    from fecfiler.celery import debug_task
+
+    debug_task.delay()
+    return Response(status=200)
+
 
 urlpatterns = [
     url(r"^api-auth/", include("rest_framework.urls", namespace="rest_framework")),
@@ -24,4 +35,5 @@ urlpatterns = [
     url(r"^api/v1/token/refresh$", refresh_jwt_token),
     path("api/v1/", include("fecfiler.triage.urls")),
     path("api/v1/", include("fecfiler.authentication.urls")),
+    url(r"^celery-test/", test_celery),
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,35 @@ services:
       - 5432:5432
     extra_hosts:
       - "host.docker.internal:host-gateway"
- 
-  redis:
 
+  redis:
+    image: redis:6.2-alpine
+    ports:
+      - '6379:6379'
+    command: redis-server
+
+  api-worker:
+    build:
+      context: './'
+      dockerfile: './Worker_Dockerfile'
+    image: fecfile-celery-worker
+    container_name: fecfile-celery-worker
+    volumes:
+      - ./django-backend:/opt/nxg_fec
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    depends_on:
+      - db
+      - redis
+    links:
+      - redis
+    environment:
+      REDIS_URL: redis://redis:6379
+      DATABASE_URL:
+      FECFILE_TEST_DB_NAME:
+      DJANGO_SETTINGS_MODULE: fecfiler.settings.local
+      DJANGO_SECRET_KEY:
+      FECFILE_FEC_WEBSITE_API_KEY: DEMO_KEY
 
   api:
     build:
@@ -36,11 +62,13 @@ services:
       - "host.docker.internal:host-gateway"
     depends_on:
       - db
-    depends_on:
-      - 
+      - redis
+    links:
+      - redis
     environment:
-      - DATABASE_URL
-      - FECFILE_TEST_DB_NAME
-      - DJANGO_SETTINGS_MODULE=fecfiler.settings.local
-      - DJANGO_SECRET_KEY
-      - FECFILE_FEC_WEBSITE_API_KEY=DEMO_KEY
+      REDIS_URL: redis://redis:6379
+      DATABASE_URL:
+      FECFILE_TEST_DB_NAME:
+      DJANGO_SETTINGS_MODULE: fecfiler.settings.local
+      DJANGO_SECRET_KEY:
+      FECFILE_FEC_WEBSITE_API_KEY: DEMO_KEY

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       - 5432:5432
     extra_hosts:
       - "host.docker.internal:host-gateway"
+ 
+  redis:
 
 
   api:
@@ -34,6 +36,8 @@ services:
       - "host.docker.internal:host-gateway"
     depends_on:
       - db
+    depends_on:
+      - 
     environment:
       - DATABASE_URL
       - FECFILE_TEST_DB_NAME

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-celery==5.2.7
+celery[redis]==5.2.7
 cfenv==0.5.2
 coreapi==2.3.3
 coreschema==0.0.4
@@ -20,7 +20,7 @@ MarkupSafe==1.1.1
 openapi-codec==1.3.2
 psycopg2==2.9.3
 PyJWT==1.6.4
-pytz==2018.5
+pytz==2021.3
 retry==0.9.2
 static3==0.6.1
 django-otp==0.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+celery==5.2.7
 cfenv==0.5.2
 coreapi==2.3.3
 coreschema==0.0.4


### PR DESCRIPTION
Configures our local development environment to spin up a Redis docker container and Web Service Worker Node running Celery (also a docker container).  The API will start with a Celery client app as defined in celery.py.  This client is how we will create tasks in the API endpoints and how we will retrieve task statuses and results.  The Redis instance is the message broker, maintaining the queue of tasks.  Lastly there is a Web Service Worker Node.  This is a docker container with the same codebase as the api.  Instead of running a django server on it, we start a celery worker/consumer.  This worker has the django code available to run the tasks (business logic, db access, FEC api access)
![web-services](https://user-images.githubusercontent.com/97105825/176229377-06f2026d-1460-4c60-8ef2-1d1eff52b4b1.png)

At the moment I just have a test endpoint that creates a task.  The celery worker outputs the request made to it's log so you can see that the whole system works