### PR TITLE
Extend grace period for dependency check alert

### DIFF
--- a/.safety.dependency.ignore
+++ b/.safety.dependency.ignore
@@ -12,6 +12,6 @@
 44717 2022-03-01 # numpy - dependencies not caught up yet
 44716 2022-03-01 # numpy - dependencies not caught up yet
 43975 2022-03-01 # urllib3 - botocore dependency needs to catch up
-48040 2022-07-01 # django
-48041 2022-07-01 # django
-48542 2022-07-01 # pyjwt
+48040 2022-08-01 # django
+48041 2022-08-01 # django
+48542 2022-08-01 # pyjwt


### PR DESCRIPTION
Lengthened grace period to Aug 1 for dependency check alerts.