### PR TITLE
Restored report_id check in scha_transaction view

### DIFF
--- a/django-backend/fecfiler/scha_transactions/views.py
+++ b/django-backend/fecfiler/scha_transactions/views.py
@@ -40,8 +40,9 @@ class SchATransactionViewSet(CommitteeOwnedViewSet):
             report_id = self.request.query_params.get("report_id")
 
         queryset = super().get_queryset()
-        if isinstance(queryset, QuerySet):
-            queryset = SchATransaction.objects.all().filter(report_id=report_id)
+        if report_id is not None and report_id != "":
+            if isinstance(queryset, QuerySet):
+                queryset = SchATransaction.objects.all().filter(report_id=report_id)
         return queryset
 
     serializer_class = SchATransactionSerializer


### PR DESCRIPTION
Fixes bug introduced in the scha_transactions views file that blocks the editing of transactions.
