### PR TITLE
Adjust migration order

### DIFF
--- a/django-backend/fecfiler/f3x_summaries/migrations/0014_patch_report_code_label_MY_20220808_1122.py
+++ b/django-backend/fecfiler/f3x_summaries/migrations/0014_patch_report_code_label_MY_20220808_1122.py
@@ -13,7 +13,7 @@ def patch_report_code_label(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('f3x_summaries', '0012_auto_20220718_1337'),
+        ('f3x_summaries', 'fecfiler/f3x_summaries/migrations/0013_auto_20220807_0743.py'),
     ]
 
     operations = [

--- a/django-backend/fecfiler/f3x_summaries/migrations/0014_patch_report_code_label_MY_20220808_1122.py
+++ b/django-backend/fecfiler/f3x_summaries/migrations/0014_patch_report_code_label_MY_20220808_1122.py
@@ -13,7 +13,7 @@ def patch_report_code_label(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('f3x_summaries', 'fecfiler/f3x_summaries/migrations/0013_auto_20220807_0743.py'),
+        ('f3x_summaries', '0013_auto_20220807_0743'),
     ]
 
     operations = [


### PR DESCRIPTION
Fixes a defect related to an uncaught merge conflict where two migrations were named with "0013" and with dependencies on "0012" 
