### PR TITLE
Updated dependency check exception dates

### DIFF
--- a/.safety.dependency.ignore
+++ b/.safety.dependency.ignore
@@ -12,6 +12,6 @@
 44717 2022-03-01 # numpy - dependencies not caught up yet
 44716 2022-03-01 # numpy - dependencies not caught up yet
 43975 2022-03-01 # urllib3 - botocore dependency needs to catch up
-48040 2022-09-06 # django
-48041 2022-09-06 # django
-48542 2022-09-06 # pyjwt
+48040 2022-10-01 # django
+48041 2022-10-01 # django
+48542 2022-10-01 # pyjwt


### PR DESCRIPTION
Hotfix to push back dependency check of django and pyjwt while code upgrade work is being performed.