### PR TITLE
Adjust endpoint permissions for login endpoints

### DIFF
--- a/django-backend/fecfiler/authentication/views.py
+++ b/django-backend/fecfiler/authentication/views.py
@@ -119,6 +119,8 @@ def handle_invalid_login(username):
 
 
 @api_view(["GET"])
+@authentication_classes([])
+@permission_classes([])
 @require_http_methods(["GET"])
 def login_redirect(request):
     request.session["user_id"] = request.user.pk
@@ -139,6 +141,8 @@ def login_redirect(request):
 
 
 @api_view(["GET"])
+@authentication_classes([])
+@permission_classes([])
 @require_http_methods(["GET"])
 def logout_redirect(request):
     response = HttpResponseRedirect(LOGIN_REDIRECT_CLIENT_URL)


### PR DESCRIPTION
Fix for redirect authentication error:

GET /api/v1/auth/logout-redirect
HTTP 403 Forbidden
Allow: OPTIONS, GET
Content-Type: application/json
Vary: Accept

{
    "detail": "Authentication credentials were not provided."
}