### PR TITLE
feature/206 .fec header issue

### DIFF
--- a/django-backend/fecfiler/web_services/dot_fec/dot_fec_composer.py
+++ b/django-backend/fecfiler/web_services/dot_fec/dot_fec_composer.py
@@ -80,7 +80,7 @@ class Header:
         self.soft_name = soft_name
         self.soft_ver = soft_ver
         self.rpt_id = rpt_id
-        self.rpt_number = (rpt_number,)
+        self.rpt_number = rpt_number
         self.hdrcomment = hdrcomment
 
 


### PR DESCRIPTION
We were getting the following error in our .fec headers which is causing webcheck to fail:

HDR^\FEC^\8.4^\FECFile Online^\0.0.1^\^\\**(None,)**^\


- 
