### PR TITLE
no schedule c property in other schedules

### DIFF
--- a/django-backend/fecfiler/transactions/serializers.py
+++ b/django-backend/fecfiler/transactions/serializers.py
@@ -89,6 +89,7 @@ class TransactionSerializerBase(
         representation = super().to_representation(instance)
         schedule_a = representation.pop("schedule_a") or []
         schedule_b = representation.pop("schedule_b") or []
+        schedule_c = representation.pop("schedule_c") or []
         if depth < 1:
             if instance.parent_transaction:
                 representation["parent_transaction"] = self.to_representation(
@@ -110,6 +111,10 @@ class TransactionSerializerBase(
             for property in schedule_b:
                 if not representation.get(property):
                     representation[property] = schedule_b[property]
+        if schedule_c:
+            for property in schedule_c:
+                if not representation.get(property):
+                    representation[property] = schedule_c[property]
         return representation
 
     def to_internal_value(self, data):
@@ -136,6 +141,7 @@ class TransactionSerializerBase(
                 "aggregate",
                 "schedule_a",
                 "schedule_b",
+                "schedule_c",
             ]
 
         fields = get_fields()


### PR DESCRIPTION
fixes bug where api would include `schedule_c: null` in response.  app would send this back to schedule_a endpoint where schedule_c is not a property