### PR TITLE
Feature/804,1035 Assign itemization value of parent/grandparent to transaction

### DIFF
--- a/django-backend/fecfiler/transactions/fixtures/test_transaction_serializer.json
+++ b/django-backend/fecfiler/transactions/fixtures/test_transaction_serializer.json
@@ -104,5 +104,56 @@
             "schedule_a_id": "33333333-0000-0000-0000-9509df48e1aa",
             "contact_1_id": "00000000-6486-4062-944f-aa0c4cbe4073"
         }
+    },
+    {
+        "comment": "tier 1 grandparent transaction",
+        "model": "transactions.transaction",
+        "pk": "aaaaabbb-3274-47d8-9388-7294a3fd4321",
+        "fields": {
+            "committee_account": "735db943-9446-462a-9be0-c820baadb622",
+            "report": "b6d60d2d-d926-4e89-ad4b-c47d152a66ae",
+            "transaction_type_identifier": "JOINT_FUNDRAISING_TRANSFER",
+            "aggregation_group": "GENERAL",
+            "_form_type": "SA12",
+            "transaction_id": "A346ABC4934C931OHAAA",
+            "entity_type": "COM",
+            "created": "2023-01-01T01:00:00.000Z",
+            "updated": "2023-01-01T01:00:00.000Z",
+            "parent_transaction_id": null
+        }
+    },
+    {
+        "comment": "tier 2 parent transaction",
+        "model": "transactions.transaction",
+        "pk": "cccccbbb-3274-47d8-9388-7294a3fd4321",
+        "fields": {
+            "committee_account": "735db943-9446-462a-9be0-c820baadb622",
+            "report": "b6d60d2d-d926-4e89-ad4b-c47d152a66ae",
+            "transaction_type_identifier": "PARTNERSHIP_JF_TRANSFER_MEMO",
+            "aggregation_group": "GENERAL",
+            "_form_type": "SA12",
+            "transaction_id": "A346ABC4934C931OHBBB",
+            "entity_type": "ORG",
+            "created": "2023-01-01T01:00:00.000Z",
+            "updated": "2023-01-01T01:00:00.000Z",
+            "parent_transaction_id": "aaaaabbb-3274-47d8-9388-7294a3fd4321"
+        }
+    },
+    {
+        "comment": "tier 3 child transaction",
+        "model": "transactions.transaction",
+        "pk": "77777bbb-3274-47d8-9388-7294a3fd4321",
+        "fields": {
+            "committee_account": "735db943-9446-462a-9be0-c820baadb622",
+            "report": "b6d60d2d-d926-4e89-ad4b-c47d152a66ae",
+            "transaction_type_identifier": "PARTNERSHIP_ATTRIBUTION_JF_TRANSFER_MEMO",
+            "aggregation_group": "GENERAL",
+            "_form_type": "SA12",
+            "transaction_id": "A346ABC4934C931OHQAC",
+            "entity_type": "IND",
+            "created": "2023-01-01T01:00:00.000Z",
+            "updated": "2023-01-01T01:00:00.000Z",
+            "parent_transaction_id": "cccccbbb-3274-47d8-9388-7294a3fd4321"
+        }
     }
 ]

--- a/django-backend/fecfiler/transactions/serializers.py
+++ b/django-backend/fecfiler/transactions/serializers.py
@@ -197,7 +197,7 @@ class TransactionSerializerBase(
             and not instance.parent_transaction.parent_transaction
         ):
             logger.info(
-                f"Transaction: itemization value for {instance.id} pulled"
+                f"Itemization value for {instance.id} pulled"
                 f" from {instance.parent_transaction.id}"
             )
             if hasattr(instance.parent_transaction, "itemized"):
@@ -210,7 +210,7 @@ class TransactionSerializerBase(
             and instance.parent_transaction.parent_transaction
         ):
             logger.info(
-                f"Transaction: itemization value for {instance.id} pulled"
+                f"Itemization value for {instance.id} pulled"
                 f" from {instance.parent_transaction.parent_transaction.id}"
             )
             if hasattr(instance.parent_transaction.parent_transaction, "itemized"):

--- a/django-backend/fecfiler/transactions/serializers.py
+++ b/django-backend/fecfiler/transactions/serializers.py
@@ -189,14 +189,16 @@ class TransactionSerializerBase(
         # Currently, there is a recursive child depth limit afterwhich the object values
         # for the parent object of a child are not longer included by the serializer.
         # Until we have refactored our tree walking to walk through the parents
-        # instead of the children, we do a manual object query from the database to get the
-        # itemization value since the serializer is no longer providing the value.
+        # instead of the children, we do a manual object query from the database
+        # to get the itemization value since the serializer is no longer
+        # providing the value.
         if (
             instance.parent_transaction
             and not instance.parent_transaction.parent_transaction
         ):
             logger.info(
-                f"Transaction: itemization value for {instance.id} pulled from {instance.parent_transaction.id}"
+                f"Transaction: itemization value for {instance.id} pulled"
+                " from {instance.parent_transaction.id}"
             )
             if hasattr(instance.parent_transaction, "itemized"):
                 representation["itemized"] = instance.parent_transaction.itemized
@@ -208,7 +210,8 @@ class TransactionSerializerBase(
             and instance.parent_transaction.parent_transaction
         ):
             logger.info(
-                f"Transaction: itemization value for {instance.id} pulled from {instance.parent_transaction.parent_transaction.id}"
+                f"Transaction: itemization value for {instance.id} pulled"
+                " from {instance.parent_transaction.parent_transaction.id}"
             )
             if hasattr(instance.parent_transaction.parent_transaction, "itemized"):
                 representation[

--- a/django-backend/fecfiler/transactions/serializers.py
+++ b/django-backend/fecfiler/transactions/serializers.py
@@ -198,7 +198,7 @@ class TransactionSerializerBase(
         ):
             logger.info(
                 f"Transaction: itemization value for {instance.id} pulled"
-                " from {instance.parent_transaction.id}"
+                f" from {instance.parent_transaction.id}"
             )
             if hasattr(instance.parent_transaction, "itemized"):
                 representation["itemized"] = instance.parent_transaction.itemized
@@ -211,7 +211,7 @@ class TransactionSerializerBase(
         ):
             logger.info(
                 f"Transaction: itemization value for {instance.id} pulled"
-                " from {instance.parent_transaction.parent_transaction.id}"
+                f" from {instance.parent_transaction.parent_transaction.id}"
             )
             if hasattr(instance.parent_transaction.parent_transaction, "itemized"):
                 representation[

--- a/django-backend/fecfiler/transactions/tests/test_serializers.py
+++ b/django-backend/fecfiler/transactions/tests/test_serializers.py
@@ -25,8 +25,7 @@ class TransactionSerializerBaseTestCase(TestCase):
 
     def test_no_transaction_type_identifier(self):
         serializer = TransactionSerializerBase(
-            data=self.missing_type_transaction,
-            context={"request": self.mock_request},
+            data=self.missing_type_transaction, context={"request": self.mock_request},
         )
         with self.assertRaises(ValidationError):
             serializer.get_schema_name({}),
@@ -125,3 +124,19 @@ class TransactionSerializerBaseTestCase(TestCase):
             id="33333333-0000-0000-0000-9509df48e1aa"
         )
         self.assertEqual("new city", third_transaction.schedule_a.contributor_city)
+
+    def test_itemization_inheritance(self):
+
+        # Get tier 1 and test children and grandchildren
+        tier1 = Transaction.objects.get(id="aaaaabbb-3274-47d8-9388-7294a3fd4321")
+        tier2 = Transaction.objects.get(id="cccccbbb-3274-47d8-9388-7294a3fd4321")
+        tier3 = Transaction.objects.get(id="77777bbb-3274-47d8-9388-7294a3fd4321")
+        self.assertEquals(tier1.itemized, True)
+        self.assertEquals(tier2.itemized, None)
+        self.assertEquals(tier3.itemized, None)
+
+        representation = TransactionSerializerBase().to_representation(tier2)
+        self.assertEquals(representation["itemized"], True)
+
+        representation = TransactionSerializerBase().to_representation(tier3)
+        self.assertEquals(representation["itemized"], True)

--- a/django-backend/fecfiler/web_services/dot_fec/dot_fec_composer.py
+++ b/django-backend/fecfiler/web_services/dot_fec/dot_fec_composer.py
@@ -40,7 +40,8 @@ def compose_transactions(report_id):
             transaction.filer_committee_id_number = (
                 FILE_AS_TEST_COMMITTEE or transaction.committee_account.committee_id
             )
-            # TODO: improve itemization inheritance.  We should not have to determine it here
+            # TODO: improve itemization inheritance.
+            # We should not have to determine it here
             root_id = (
                 transaction.parent_transaction.parent_transaction.id
                 if transaction.parent_transaction

--- a/django-backend/fecfiler/web_services/dot_fec/dot_fec_composer.py
+++ b/django-backend/fecfiler/web_services/dot_fec/dot_fec_composer.py
@@ -4,7 +4,6 @@ from fecfiler.web_services.models import UploadSubmission
 from fecfiler.transactions.models import Transaction
 from fecfiler.transactions.managers import Schedule
 from django.core.exceptions import ObjectDoesNotExist
-from django.db.models.functions import Coalesce
 from .dot_fec_serializer import serialize_instance, CRLF_STR
 from fecfiler.settings import FILE_AS_TEST_COMMITTEE, OUTPUT_TEST_INFO_IN_DOT_FEC
 

--- a/django-backend/fecfiler/web_services/dot_fec/dot_fec_composer.py
+++ b/django-backend/fecfiler/web_services/dot_fec/dot_fec_composer.py
@@ -48,6 +48,7 @@ def compose_transactions(report_id):
                 else transaction.parent_transaction.id
                 if transaction.parent_transaction
                 else transaction.id
+            )
             transaction.itemized = transactions.filter(id=root_id).first().itemized
         return [t for t in transactions if t.itemized]
     else:

--- a/django-backend/fecfiler/web_services/dot_fec/schema_fields/SchC.json
+++ b/django-backend/fecfiler/web_services/dot_fec/schema_fields/SchC.json
@@ -59,7 +59,6 @@
         "path": "schedule_c.loan_incurred_date"
     },
     "loan_due_date": {
-        "serializer": "DATE",
         "path": "schedule_c.loan_due_date"
     },
     "loan_interest_rate": {

--- a/django-backend/fecfiler/web_services/dot_fec/schema_fields/SchC1.json
+++ b/django-backend/fecfiler/web_services/dot_fec/schema_fields/SchC1.json
@@ -2,6 +2,12 @@
     "form_type": {},
     "filer_committee_id_number": {},
     "transaction_id": {},
+    "back_reference_tran_id_number": {
+        "path": "parent_transaction.transaction_id"
+    },
+    "back_reference_sched_name": {
+        "path": "parent_transaction.form_type"
+    },
     "entity_type": {},
     "lender_organization_name": {
         "path": "schedule_c1.lender_organization_name"
@@ -32,7 +38,6 @@
         "path": "schedule_c1.loan_incurred_date"
     },
     "loan_due_date": {
-        "serializer": "DATE",
         "path": "schedule_c1.loan_due_date"
     },
     "loan_restructured": {
@@ -147,5 +152,4 @@
         "serializer": "DATE",
         "path": "schedule_c1.authorized_date_signed"
     }
-
 }

--- a/django-backend/fecfiler/web_services/dot_fec/schema_fields/SchC2.json
+++ b/django-backend/fecfiler/web_services/dot_fec/schema_fields/SchC2.json
@@ -2,6 +2,12 @@
     "form_type": {},
     "filer_committee_id_number": {},
     "transaction_id": {},
+    "back_reference_tran_id_number": {
+        "path": "parent_transaction.transaction_id"
+    },
+    "back_reference_sched_name": {
+        "path": "parent_transaction.form_type"
+    },
     "entity_type": {},
     "guarantor_last_name": {
         "path": "schedule_c2.guarantor_last_name"


### PR DESCRIPTION
Updated the Transaction serializer to_representation method so that a transaction's itemized value matches that of its parent's or grandparent's itemization value so all descendants of a tier 1 transaction hold the tier 1 itemization value.

EDIT: also patches itemization when building .fec.  We need to be careful when using .itemized on the server and when filtering on `itemized` in queries because until we update the manager to handle itemization inheritance, it will be inaccurate