### PR TITLE
Patch/documentation Remove spaces around = in environment vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ You should set the following environment variables in the shell where you are ru
 Proper values for the development variables are shown here as an example
 
 ```
-export DATABASE_URL = "postgres://postgres:postgres@db/postgres"
-export FECFILE_TEST_DB_NAME = "postgres"
-export DJANGO_SECRET_KEY = "If_using_test_db_use_secret_key_in_cloud.gov"
+export DATABASE_URL="postgres://postgres:postgres@db/postgres"
+export FECFILE_TEST_DB_NAME="postgres"
+export DJANGO_SECRET_KEY="If_using_test_db_use_secret_key_in_cloud.gov"
 ```
 
 ### Shut down the containers
@@ -60,14 +60,14 @@ _Special Note:_ If the fecfile-validate repo was updated, the commit of the upda
 ### Create a feature branch
 
 Using git-flow extensions:
-`   git flow feature start feature_branch
-  `
+` git flow feature start feature_branch
+`
 
 Without the git-flow extensions:
-`   git checkout develop
+` git checkout develop
     git pull
     git checkout -b feature/feature_branch develop
-  `
+`
 
 - Developer creates a GitHub PR when ready to merge to `develop` branch
 - Reviewer reviews and merges feature branch into `develop` via GitHub


### PR DESCRIPTION
Remove spaces around = for export environment variables in README. The spaces were causing setup problems.