### PR TITLE
Patch 325

### DIFF
--- a/django-backend/fecfiler/web_services/summary/summary.py
+++ b/django-backend/fecfiler/web_services/summary/summary.py
@@ -23,8 +23,8 @@ class SummaryService:
         )
 
     def calculate_summary(self):
-        summary_a = self.calculate_summary_column_a()
-        summary_b = self.calculate_summary_column_b()
+        column_a = self.calculate_summary_column_a()
+        column_b = self.calculate_summary_column_b()
 
 
 
@@ -35,21 +35,43 @@ class SummaryService:
         ).order_by("coverage_from_date")
 
         if reports_from_prior_years.count() > 0:
-            summary_b["line_6a"] = reports_from_prior_years.last().form_3x.L8_cash_on_hand_close_ytd  # noqa: E501
+            column_b["line_6a"] = reports_from_prior_years.last().form_3x.L8_cash_on_hand_close_ytd  # noqa: E501
         elif self.previous_report:
-                summary_b["line_6a"] = self.previous_report.form_3x.L6a_cash_on_hand_jan_1_ytd  # noqa: E501
+                column_b["line_6a"] = self.previous_report.form_3x.L6a_cash_on_hand_jan_1_ytd  # noqa: E501
+        else:
+            #first report
+            column_b["line_6a"] = self.report.form_3x.L6a_cash_on_hand_jan_1_ytd
 
         if self.previous_report:
-            summary_a["line_6b"] = self.previous_report.form_3x.L8_cash_on_hand_at_close_period  # noqa: E501
+            column_a["line_6b"] = self.previous_report.form_3x.L8_cash_on_hand_at_close_period  # noqa: E501
         else:
-            summary_a["line_6b"] = summary_b["line_6a"]
+            # first report
+            column_a["line_6b"] = self.report.form_3x.L6a_cash_on_hand_jan_1_ytd
 
+        column_a["line_6d"] = (
+            column_a["line_6b"]
+            + column_a["line_6c"]
+        )
 
-        return summary_a, summary_b
+        column_a["line_8"] = (
+            column_a["line_6d"]
+            - column_a["line_7"]
+        )
+
+        column_b["line_6d"] = (
+            column_b["line_6a"]
+            + column_b["line_6c"]
+        )
+        column_b["line_8"] = (
+            column_b["line_6d"]
+            - column_b["line_7"]
+        )
+        return column_a, column_b
+    
 
     def calculate_summary_column_a(self):
         report_transactions = Transaction.objects.filter(report_id=self.report.id)
-        summary = report_transactions.aggregate(
+        column_a = report_transactions.aggregate(
             line_11ai=self.get_line("SA11AI"),
             line_11aii=self.get_line("SA11AII"),
             line_11b=self.get_line("SA11B"),
@@ -78,117 +100,109 @@ class SummaryService:
             temp_sd10=self.get_line("SD10", field="balance_at_close")
         )
 
-        summary["line_9"] = (
-            summary["temp_sc9"]
-            + summary["temp_sd9"]
+        column_a["line_9"] = (
+            column_a["temp_sc9"]
+            + column_a["temp_sd9"]
         )
-        summary["line_10"] = (
-            summary["temp_sc10"]
-            + summary["temp_sd10"]
+        column_a["line_10"] = (
+            column_a["temp_sc10"]
+            + column_a["temp_sd10"]
         )
-        summary["line_11aiii"] = (
-            summary["line_11ai"]
-            + summary["line_11aii"]
+        column_a["line_11aiii"] = (
+            column_a["line_11ai"]
+            + column_a["line_11aii"]
         )
-        summary["line_11d"] = (
-            summary["line_11aiii"]
-            + summary["line_11b"]
-            + summary["line_11c"]
+        column_a["line_11d"] = (
+            column_a["line_11aiii"]
+            + column_a["line_11b"]
+            + column_a["line_11c"]
         )
-        summary["line_18c"] = Decimal(0)  # Stubbed out until a future ticket
-        summary["line_21ai"] = Decimal(0)  # Stubbed out until a future ticket
-        summary["line_21aii"] = Decimal(0)  # Stubbed out until a future ticket
-        summary["line_21c"] = (
-            summary["line_21ai"]
-            + summary["line_21aii"]
-            + summary["line_21b"]
+        column_a["line_18c"] = Decimal(0)  # Stubbed out until a future ticket
+        column_a["line_21ai"] = Decimal(0)  # Stubbed out until a future ticket
+        column_a["line_21aii"] = Decimal(0)  # Stubbed out until a future ticket
+        column_a["line_21c"] = (
+            column_a["line_21ai"]
+            + column_a["line_21aii"]
+            + column_a["line_21b"]
         )
-        summary["line_25"] = Decimal(0)  # Stubbed out until a future ticket
-        summary["line_28d"] = (
-            summary["line_28a"]
-            + summary["line_28b"]
-            + summary["line_28c"]
+        column_a["line_25"] = Decimal(0)  # Stubbed out until a future ticket
+        column_a["line_28d"] = (
+            column_a["line_28a"]
+            + column_a["line_28b"]
+            + column_a["line_28c"]
         )
-        summary["line_30ai"] = Decimal(0)  # Stubbed out until a future ticket
-        summary["line_30aii"] = Decimal(0)  # Stubbed out until a future ticket
-        summary["line_30c"] = (
-            summary["line_30ai"]
-            + summary["line_30aii"]
-            + summary["line_30b"]
+        column_a["line_30ai"] = Decimal(0)  # Stubbed out until a future ticket
+        column_a["line_30aii"] = Decimal(0)  # Stubbed out until a future ticket
+        column_a["line_30c"] = (
+            column_a["line_30ai"]
+            + column_a["line_30aii"]
+            + column_a["line_30b"]
         )
-        summary["line_31"] = (
-            summary["line_21c"]
-            + summary["line_22"]
-            + summary["line_23"]
-            + summary["line_24"]
-            + summary["line_25"]
-            + summary["line_26"]
-            + summary["line_27"]
-            + summary["line_28d"]
-            + summary["line_29"]
-            + summary["line_30c"]
+        column_a["line_31"] = (
+            column_a["line_21c"]
+            + column_a["line_22"]
+            + column_a["line_23"]
+            + column_a["line_24"]
+            + column_a["line_25"]
+            + column_a["line_26"]
+            + column_a["line_27"]
+            + column_a["line_28d"]
+            + column_a["line_29"]
+            + column_a["line_30c"]
         )
-        summary["line_32"] = (
-            summary["line_31"]
-            - summary["line_21aii"]
-            - summary["line_30aii"]
+        column_a["line_32"] = (
+            column_a["line_31"]
+            - column_a["line_21aii"]
+            - column_a["line_30aii"]
         )
-        summary["line_33"] = (
-            summary["line_11d"]
+        column_a["line_33"] = (
+            column_a["line_11d"]
         )
-        summary["line_34"] = (
-            summary["line_28d"]
+        column_a["line_34"] = (
+            column_a["line_28d"]
         )
-        summary["line_35"] = (
-            summary["line_33"]
-            - summary["line_34"]
+        column_a["line_35"] = (
+            column_a["line_33"]
+            - column_a["line_34"]
         )
-        summary["line_36"] = (
-            summary["line_21ai"]
-            + summary["line_21b"]
+        column_a["line_36"] = (
+            column_a["line_21ai"]
+            + column_a["line_21b"]
         )
-        summary["line_37"] = (
-            summary["line_15"]
+        column_a["line_37"] = (
+            column_a["line_15"]
         )
-        summary["line_38"] = (
-            summary["line_36"]
-            - summary["line_37"]
+        column_a["line_38"] = (
+            column_a["line_36"]
+            - column_a["line_37"]
         )
-        summary["line_6c"] = (
-            summary["line_11d"]
-            + summary["line_12"]
-            + summary["line_13"]
-            + summary["line_14"]
-            + summary["line_15"]
-            + summary["line_16"]
-            + summary["line_17"]
-            + summary["line_18c"]
+        column_a["line_6c"] = (
+            column_a["line_11d"]
+            + column_a["line_12"]
+            + column_a["line_13"]
+            + column_a["line_14"]
+            + column_a["line_15"]
+            + column_a["line_16"]
+            + column_a["line_17"]
+            + column_a["line_18c"]
         )
-        summary["line_6d"] = (
-            summary["line_6b"]
-            + summary["line_6c"]
+        column_a["line_7"] = (
+            column_a["line_31"]
         )
-        summary["line_7"] = (
-            summary["line_31"]
+        column_a["line_19"] = (
+            column_a["line_6c"]
         )
-        summary["line_8"] = (
-            summary["line_6d"]
-            - summary["line_7"]
-        )
-        summary["line_19"] = (
-            summary["line_6c"]
-        )
-        summary["line_20"] = (
-            summary["line_19"]
-            - summary["line_18c"]
+        column_a["line_20"] = (
+            column_a["line_19"]
+            - column_a["line_18c"]
         )
 
         # Remove temporary aggregations to clean up the summary
-        for key in list(summary.keys()):
+        for key in list(column_a.keys()):
             if key.startswith("temp_"):
-                summary.pop(key)
+                column_a.pop(key)
 
-        return summary
+        return column_a
 
     def calculate_summary_column_b(self):
         committee = self.report.committee_account
@@ -200,7 +214,7 @@ class SummaryService:
         )
 
         # build summary
-        summary = ytd_transactions.aggregate(
+        column_b = ytd_transactions.aggregate(
             line_11ai=self.get_line("SA11AI"),
             line_11aii=self.get_line("SA11AII"),
             line_11b=self.get_line("SA11B"),
@@ -224,104 +238,96 @@ class SummaryService:
             line_30b=self.get_line("SB30B"),
         )
 
-        summary["line_11aiii"] = (
-            summary["line_11ai"]
-            + summary["line_11aii"]
+        column_b["line_11aiii"] = (
+            column_b["line_11ai"]
+            + column_b["line_11aii"]
         )
-        summary["line_11d"] = (
-            summary["line_11aiii"]
-            + summary["line_11b"]
-            + summary["line_11c"]
+        column_b["line_11d"] = (
+            column_b["line_11aiii"]
+            + column_b["line_11b"]
+            + column_b["line_11c"]
         )
-        summary["line_18c"] = Decimal(0)  # Stubbed out until a future ticket
-        summary["line_21ai"] = Decimal(0)  # Stubbed out until a future ticket
-        summary["line_21aii"] = Decimal(0)  # Stubbed out until a future ticket
-        summary["line_21c"] = (
-            summary["line_21ai"]
-            + summary["line_21aii"]
-            + summary["line_21b"]
+        column_b["line_18c"] = Decimal(0)  # Stubbed out until a future ticket
+        column_b["line_21ai"] = Decimal(0)  # Stubbed out until a future ticket
+        column_b["line_21aii"] = Decimal(0)  # Stubbed out until a future ticket
+        column_b["line_21c"] = (
+            column_b["line_21ai"]
+            + column_b["line_21aii"]
+            + column_b["line_21b"]
         )
-        summary["line_25"] = Decimal(0)  # Stubbed out until a future ticket
-        summary["line_28d"] = (
-            summary["line_28a"]
-            + summary["line_28b"]
-            + summary["line_28c"]
+        column_b["line_25"] = Decimal(0)  # Stubbed out until a future ticket
+        column_b["line_28d"] = (
+            column_b["line_28a"]
+            + column_b["line_28b"]
+            + column_b["line_28c"]
         )
-        summary["line_30ai"] = Decimal(0)  # Stubbed out until a future ticket
-        summary["line_30aii"] = Decimal(0)  # Stubbed out until a future ticket
-        summary["line_30c"] = (
-            summary["line_30ai"]
-            + summary["line_30aii"]
-            + summary["line_30b"]
+        column_b["line_30ai"] = Decimal(0)  # Stubbed out until a future ticket
+        column_b["line_30aii"] = Decimal(0)  # Stubbed out until a future ticket
+        column_b["line_30c"] = (
+            column_b["line_30ai"]
+            + column_b["line_30aii"]
+            + column_b["line_30b"]
         )
-        summary["line_31"] = (
-            summary["line_21c"]
-            + summary["line_22"]
-            + summary["line_23"]
-            + summary["line_24"]
-            + summary["line_25"]
-            + summary["line_26"]
-            + summary["line_27"]
-            + summary["line_28d"]
-            + summary["line_29"]
-            + summary["line_30c"]
+        column_b["line_31"] = (
+            column_b["line_21c"]
+            + column_b["line_22"]
+            + column_b["line_23"]
+            + column_b["line_24"]
+            + column_b["line_25"]
+            + column_b["line_26"]
+            + column_b["line_27"]
+            + column_b["line_28d"]
+            + column_b["line_29"]
+            + column_b["line_30c"]
         )
-        summary["line_32"] = (
-            summary["line_31"]
-            - summary["line_21aii"]
-            - summary["line_30aii"]
+        column_b["line_32"] = (
+            column_b["line_31"]
+            - column_b["line_21aii"]
+            - column_b["line_30aii"]
         )
-        summary["line_33"] = (
-            summary["line_11d"]
+        column_b["line_33"] = (
+            column_b["line_11d"]
         )
-        summary["line_34"] = (
-            summary["line_28d"]
+        column_b["line_34"] = (
+            column_b["line_28d"]
         )
-        summary["line_35"] = (
-            summary["line_33"]
-            - summary["line_34"]
+        column_b["line_35"] = (
+            column_b["line_33"]
+            - column_b["line_34"]
         )
-        summary["line_36"] = (
-            summary["line_21ai"]
-            + summary["line_21b"]
+        column_b["line_36"] = (
+            column_b["line_21ai"]
+            + column_b["line_21b"]
         )
-        summary["line_37"] = (
-            summary["line_15"]
+        column_b["line_37"] = (
+            column_b["line_15"]
         )
-        summary["line_38"] = (
-            summary["line_36"]
-            - summary["line_37"]
+        column_b["line_38"] = (
+            column_b["line_36"]
+            - column_b["line_37"]
         )
-        summary["line_6c"] = (
-            summary["line_11d"]
-            + summary["line_12"]
-            + summary["line_13"]
-            + summary["line_14"]
-            + summary["line_15"]
-            + summary["line_16"]
-            + summary["line_17"]
-            + summary["line_18c"]
+        column_b["line_6c"] = (
+            column_b["line_11d"]
+            + column_b["line_12"]
+            + column_b["line_13"]
+            + column_b["line_14"]
+            + column_b["line_15"]
+            + column_b["line_16"]
+            + column_b["line_17"]
+            + column_b["line_18c"]
         )
-        summary["line_6d"] = (
-            summary["line_6a"]
-            + summary["line_6c"]
+        column_b["line_7"] = (
+            column_b["line_31"]
         )
-        summary["line_7"] = (
-            summary["line_31"]
+        column_b["line_19"] = (
+            column_b["line_6c"]
         )
-        summary["line_8"] = (
-            summary["line_6d"]
-            - summary["line_7"]
-        )
-        summary["line_19"] = (
-            summary["line_6c"]
-        )
-        summary["line_20"] = (
-            summary["line_19"]
-            - summary["line_18c"]
+        column_b["line_20"] = (
+            column_b["line_19"]
+            - column_b["line_18c"]
         )
 
-        return summary
+        return column_b
 
     def get_line(self, form_type, field="amount"):
         query = Q(~Q(memo_code=True), form_type=form_type)

--- a/django-backend/fecfiler/web_services/summary/summary.py
+++ b/django-backend/fecfiler/web_services/summary/summary.py
@@ -224,17 +224,17 @@ class SummaryService:
         ).order_by("coverage_from_date")
 
         if reports_from_prior_years.count() > 0:
-            column_b["line_6a"] = reports_from_prior_years.last().form_3x.L8_cash_on_hand_close_ytd # noqa: E501
+            column_b["line_6a"] = reports_from_prior_years.last().form_3x.L8_cash_on_hand_close_ytd  # noqa: E501
         elif self.previous_report:
             column_b["line_6a"] = self.previous_report.form_3x.L6a_cash_on_hand_jan_1_ytd  # noqa: E501
         else:
-            #  user defined cash on hand
+            # user defined cash on hand
             column_b["line_6a"] = self.report.form_3x.L6a_cash_on_hand_jan_1_ytd
 
         if self.previous_report:
-            column_a["line_6b"] = self.previous_report.form_3x.L8_cash_on_hand_at_close_period # noqa: E501
+            column_a["line_6b"] = self.previous_report.form_3x.L8_cash_on_hand_at_close_period  # noqa: E501
         else:
-            #  user defined cash on hand
+            # user defined cash on hand
             column_a["line_6b"] = self.report.form_3x.L6a_cash_on_hand_jan_1_ytd
 
         if column_a["line_6b"] and column_b["line_6a"]:

--- a/django-backend/fecfiler/web_services/summary/summary.py
+++ b/django-backend/fecfiler/web_services/summary/summary.py
@@ -228,13 +228,13 @@ class SummaryService:
         elif self.previous_report:
             column_b["line_6a"] = self.previous_report.form_3x.L6a_cash_on_hand_jan_1_ytd  # noqa: E501
         else:
-            #  first report
+            #  user defined cash on hand
             column_b["line_6a"] = self.report.form_3x.L6a_cash_on_hand_jan_1_ytd
 
         if self.previous_report:
             column_a["line_6b"] = self.previous_report.form_3x.L8_cash_on_hand_at_close_period # noqa: E501
         else:
-            #  first report
+            #  user defined cash on hand
             column_a["line_6b"] = self.report.form_3x.L6a_cash_on_hand_jan_1_ytd
 
         if column_a["line_6b"] and column_b["line_6a"]:

--- a/django-backend/fecfiler/web_services/summary/summary.py
+++ b/django-backend/fecfiler/web_services/summary/summary.py
@@ -26,48 +26,9 @@ class SummaryService:
         column_a = self.calculate_summary_column_a()
         column_b = self.calculate_summary_column_b()
 
+        column_a, column_b = self.calculate_cash_on_hand_fields(column_a, column_b)
 
-
-        reports_from_prior_years = Report.objects.filter(
-            committee_account=self.report.committee_account,
-            coverage_through_date__year__lt=self.report.coverage_from_date.year,
-            form_3x__isnull=False
-        ).order_by("coverage_from_date")
-
-        if reports_from_prior_years.count() > 0:
-            column_b["line_6a"] = reports_from_prior_years.last().form_3x.L8_cash_on_hand_close_ytd  # noqa: E501
-        elif self.previous_report:
-                column_b["line_6a"] = self.previous_report.form_3x.L6a_cash_on_hand_jan_1_ytd  # noqa: E501
-        else:
-            #first report
-            column_b["line_6a"] = self.report.form_3x.L6a_cash_on_hand_jan_1_ytd
-
-        if self.previous_report:
-            column_a["line_6b"] = self.previous_report.form_3x.L8_cash_on_hand_at_close_period  # noqa: E501
-        else:
-            # first report
-            column_a["line_6b"] = self.report.form_3x.L6a_cash_on_hand_jan_1_ytd
-
-        column_a["line_6d"] = (
-            column_a["line_6b"]
-            + column_a["line_6c"]
-        )
-
-        column_a["line_8"] = (
-            column_a["line_6d"]
-            - column_a["line_7"]
-        )
-
-        column_b["line_6d"] = (
-            column_b["line_6a"]
-            + column_b["line_6c"]
-        )
-        column_b["line_8"] = (
-            column_b["line_6d"]
-            - column_b["line_7"]
-        )
         return column_a, column_b
-    
 
     def calculate_summary_column_a(self):
         report_transactions = Transaction.objects.filter(report_id=self.report.id)
@@ -97,46 +58,29 @@ class SummaryService:
             temp_sc9=self.get_line("SC/9", field="loan_balance"),
             temp_sd9=self.get_line("SD9", field="balance_at_close"),
             temp_sc10=self.get_line("SC/10", field="loan_balance"),
-            temp_sd10=self.get_line("SD10", field="balance_at_close")
+            temp_sd10=self.get_line("SD10", field="balance_at_close"),
         )
 
-        column_a["line_9"] = (
-            column_a["temp_sc9"]
-            + column_a["temp_sd9"]
-        )
-        column_a["line_10"] = (
-            column_a["temp_sc10"]
-            + column_a["temp_sd10"]
-        )
-        column_a["line_11aiii"] = (
-            column_a["line_11ai"]
-            + column_a["line_11aii"]
-        )
+        column_a["line_9"] = column_a["temp_sc9"] + column_a["temp_sd9"]
+        column_a["line_10"] = column_a["temp_sc10"] + column_a["temp_sd10"]
+        column_a["line_11aiii"] = column_a["line_11ai"] + column_a["line_11aii"]
         column_a["line_11d"] = (
-            column_a["line_11aiii"]
-            + column_a["line_11b"]
-            + column_a["line_11c"]
+            column_a["line_11aiii"] + column_a["line_11b"] + column_a["line_11c"]
         )
         column_a["line_18c"] = Decimal(0)  # Stubbed out until a future ticket
         column_a["line_21ai"] = Decimal(0)  # Stubbed out until a future ticket
         column_a["line_21aii"] = Decimal(0)  # Stubbed out until a future ticket
         column_a["line_21c"] = (
-            column_a["line_21ai"]
-            + column_a["line_21aii"]
-            + column_a["line_21b"]
+            column_a["line_21ai"] + column_a["line_21aii"] + column_a["line_21b"]
         )
         column_a["line_25"] = Decimal(0)  # Stubbed out until a future ticket
         column_a["line_28d"] = (
-            column_a["line_28a"]
-            + column_a["line_28b"]
-            + column_a["line_28c"]
+            column_a["line_28a"] + column_a["line_28b"] + column_a["line_28c"]
         )
         column_a["line_30ai"] = Decimal(0)  # Stubbed out until a future ticket
         column_a["line_30aii"] = Decimal(0)  # Stubbed out until a future ticket
         column_a["line_30c"] = (
-            column_a["line_30ai"]
-            + column_a["line_30aii"]
-            + column_a["line_30b"]
+            column_a["line_30ai"] + column_a["line_30aii"] + column_a["line_30b"]
         )
         column_a["line_31"] = (
             column_a["line_21c"]
@@ -151,31 +95,14 @@ class SummaryService:
             + column_a["line_30c"]
         )
         column_a["line_32"] = (
-            column_a["line_31"]
-            - column_a["line_21aii"]
-            - column_a["line_30aii"]
+            column_a["line_31"] - column_a["line_21aii"] - column_a["line_30aii"]
         )
-        column_a["line_33"] = (
-            column_a["line_11d"]
-        )
-        column_a["line_34"] = (
-            column_a["line_28d"]
-        )
-        column_a["line_35"] = (
-            column_a["line_33"]
-            - column_a["line_34"]
-        )
-        column_a["line_36"] = (
-            column_a["line_21ai"]
-            + column_a["line_21b"]
-        )
-        column_a["line_37"] = (
-            column_a["line_15"]
-        )
-        column_a["line_38"] = (
-            column_a["line_36"]
-            - column_a["line_37"]
-        )
+        column_a["line_33"] = column_a["line_11d"]
+        column_a["line_34"] = column_a["line_28d"]
+        column_a["line_35"] = column_a["line_33"] - column_a["line_34"]
+        column_a["line_36"] = column_a["line_21ai"] + column_a["line_21b"]
+        column_a["line_37"] = column_a["line_15"]
+        column_a["line_38"] = column_a["line_36"] - column_a["line_37"]
         column_a["line_6c"] = (
             column_a["line_11d"]
             + column_a["line_12"]
@@ -186,16 +113,9 @@ class SummaryService:
             + column_a["line_17"]
             + column_a["line_18c"]
         )
-        column_a["line_7"] = (
-            column_a["line_31"]
-        )
-        column_a["line_19"] = (
-            column_a["line_6c"]
-        )
-        column_a["line_20"] = (
-            column_a["line_19"]
-            - column_a["line_18c"]
-        )
+        column_a["line_7"] = column_a["line_31"]
+        column_a["line_19"] = column_a["line_6c"]
+        column_a["line_20"] = column_a["line_19"] - column_a["line_18c"]
 
         # Remove temporary aggregations to clean up the summary
         for key in list(column_a.keys()):
@@ -210,7 +130,9 @@ class SummaryService:
         report_year = report_date.year
 
         ytd_transactions = Transaction.objects.filter(
-            committee_account=committee, date__year=report_year, date__lte=report_date,
+            committee_account=committee,
+            date__year=report_year,
+            date__lte=report_date,
         )
 
         # build summary
@@ -238,35 +160,24 @@ class SummaryService:
             line_30b=self.get_line("SB30B"),
         )
 
-        column_b["line_11aiii"] = (
-            column_b["line_11ai"]
-            + column_b["line_11aii"]
-        )
+        column_b["line_11aiii"] = column_b["line_11ai"] + column_b["line_11aii"]
         column_b["line_11d"] = (
-            column_b["line_11aiii"]
-            + column_b["line_11b"]
-            + column_b["line_11c"]
+            column_b["line_11aiii"] + column_b["line_11b"] + column_b["line_11c"]
         )
         column_b["line_18c"] = Decimal(0)  # Stubbed out until a future ticket
         column_b["line_21ai"] = Decimal(0)  # Stubbed out until a future ticket
         column_b["line_21aii"] = Decimal(0)  # Stubbed out until a future ticket
         column_b["line_21c"] = (
-            column_b["line_21ai"]
-            + column_b["line_21aii"]
-            + column_b["line_21b"]
+            column_b["line_21ai"] + column_b["line_21aii"] + column_b["line_21b"]
         )
         column_b["line_25"] = Decimal(0)  # Stubbed out until a future ticket
         column_b["line_28d"] = (
-            column_b["line_28a"]
-            + column_b["line_28b"]
-            + column_b["line_28c"]
+            column_b["line_28a"] + column_b["line_28b"] + column_b["line_28c"]
         )
         column_b["line_30ai"] = Decimal(0)  # Stubbed out until a future ticket
         column_b["line_30aii"] = Decimal(0)  # Stubbed out until a future ticket
         column_b["line_30c"] = (
-            column_b["line_30ai"]
-            + column_b["line_30aii"]
-            + column_b["line_30b"]
+            column_b["line_30ai"] + column_b["line_30aii"] + column_b["line_30b"]
         )
         column_b["line_31"] = (
             column_b["line_21c"]
@@ -281,31 +192,14 @@ class SummaryService:
             + column_b["line_30c"]
         )
         column_b["line_32"] = (
-            column_b["line_31"]
-            - column_b["line_21aii"]
-            - column_b["line_30aii"]
+            column_b["line_31"] - column_b["line_21aii"] - column_b["line_30aii"]
         )
-        column_b["line_33"] = (
-            column_b["line_11d"]
-        )
-        column_b["line_34"] = (
-            column_b["line_28d"]
-        )
-        column_b["line_35"] = (
-            column_b["line_33"]
-            - column_b["line_34"]
-        )
-        column_b["line_36"] = (
-            column_b["line_21ai"]
-            + column_b["line_21b"]
-        )
-        column_b["line_37"] = (
-            column_b["line_15"]
-        )
-        column_b["line_38"] = (
-            column_b["line_36"]
-            - column_b["line_37"]
-        )
+        column_b["line_33"] = column_b["line_11d"]
+        column_b["line_34"] = column_b["line_28d"]
+        column_b["line_35"] = column_b["line_33"] - column_b["line_34"]
+        column_b["line_36"] = column_b["line_21ai"] + column_b["line_21b"]
+        column_b["line_37"] = column_b["line_15"]
+        column_b["line_38"] = column_b["line_36"] - column_b["line_37"]
         column_b["line_6c"] = (
             column_b["line_11d"]
             + column_b["line_12"]
@@ -316,18 +210,39 @@ class SummaryService:
             + column_b["line_17"]
             + column_b["line_18c"]
         )
-        column_b["line_7"] = (
-            column_b["line_31"]
-        )
-        column_b["line_19"] = (
-            column_b["line_6c"]
-        )
-        column_b["line_20"] = (
-            column_b["line_19"]
-            - column_b["line_18c"]
-        )
+        column_b["line_7"] = column_b["line_31"]
+        column_b["line_19"] = column_b["line_6c"]
+        column_b["line_20"] = column_b["line_19"] - column_b["line_18c"]
 
         return column_b
+
+    def calculate_cash_on_hand_fields(self, column_a, column_b):
+        reports_from_prior_years = Report.objects.filter(
+            committee_account=self.report.committee_account,
+            coverage_through_date__year__lt=self.report.coverage_from_date.year,
+            form_3x__isnull=False,
+        ).order_by("coverage_from_date")
+
+        if reports_from_prior_years.count() > 0:
+            column_b["line_6a"] = reports_from_prior_years.last().form_3x.L8_cash_on_hand_close_ytd # noqa: E501
+        elif self.previous_report:
+            column_b["line_6a"] = self.previous_report.form_3x.L6a_cash_on_hand_jan_1_ytd  # noqa: E501
+        else:
+            # first report
+            column_b["line_6a"] = self.report.form_3x.L6a_cash_on_hand_jan_1_ytd
+
+        if self.previous_report:
+            column_a["line_6b"] = self.previous_report.form_3x.L8_cash_on_hand_at_close_period # noqa: E501
+        else:
+            # first report
+            column_a["line_6b"] = self.report.form_3x.L6a_cash_on_hand_jan_1_ytd
+
+        if column_a["line_6b"] and column_b["line_6a"]:
+            column_a["line_6d"] = column_a["line_6b"] + column_a["line_6c"]
+            column_a["line_8"] = column_a["line_6d"] - column_a["line_7"]
+            column_b["line_6d"] = column_b["line_6a"] + column_b["line_6c"]
+            column_b["line_8"] = column_b["line_6d"] - column_b["line_7"]
+        return column_a, column_b
 
     def get_line(self, form_type, field="amount"):
         query = Q(~Q(memo_code=True), form_type=form_type)

--- a/django-backend/fecfiler/web_services/summary/summary.py
+++ b/django-backend/fecfiler/web_services/summary/summary.py
@@ -228,13 +228,13 @@ class SummaryService:
         elif self.previous_report:
             column_b["line_6a"] = self.previous_report.form_3x.L6a_cash_on_hand_jan_1_ytd  # noqa: E501
         else:
-            # first report
+            #  first report
             column_b["line_6a"] = self.report.form_3x.L6a_cash_on_hand_jan_1_ytd
 
         if self.previous_report:
             column_a["line_6b"] = self.previous_report.form_3x.L8_cash_on_hand_at_close_period # noqa: E501
         else:
-            # first report
+            #  first report
             column_a["line_6b"] = self.report.form_3x.L6a_cash_on_hand_jan_1_ytd
 
         if column_a["line_6b"] and column_b["line_6a"]:

--- a/django-backend/fecfiler/web_services/summary/tasks.py
+++ b/django-backend/fecfiler/web_services/summary/tasks.py
@@ -51,9 +51,7 @@ def calculate_summary(report_id):
 
     for report in claimed_reports:
         summary_service = SummaryService(report)
-        summary = summary_service.calculate_summary()
-        a = summary["a"]
-        b = summary["b"]
+        a, b = summary_service.calculate_summary()
 
         # line 6a
         report.form_3x.L6a_cash_on_hand_jan_1_ytd = b["line_6a"]

--- a/django-backend/fecfiler/web_services/summary/tasks.py
+++ b/django-backend/fecfiler/web_services/summary/tasks.py
@@ -26,7 +26,7 @@ def get_reports_to_calculate(primary_report):
     reports_to_recalculate = Report.objects.filter(
         ~Q(calculation_status=CalculationState.SUCCEEDED),
         coverage_from_date__year=report_year,
-        coverage_through_date__lte=primary_report.coverage_through_date
+        coverage_through_date__lte=primary_report.coverage_through_date,
     ).order_by("coverage_through_date")
 
     if len(reports_to_recalculate) > 0:
@@ -45,7 +45,7 @@ def calculate_summary(report_id):
     calculation_token = uuid.uuid4()
     reports_to_recalculate.update(
         calculation_token=calculation_token,
-        calculation_status=CalculationState.CALCULATING
+        calculation_status=CalculationState.CALCULATING,
     )
     claimed_reports = list(reports_to_recalculate)
 
@@ -54,21 +54,21 @@ def calculate_summary(report_id):
         a, b = summary_service.calculate_summary()
 
         # line 6a
-        report.form_3x.L6a_cash_on_hand_jan_1_ytd = b["line_6a"]
+        report.form_3x.L6a_cash_on_hand_jan_1_ytd = b.get("line_6a", None)
         # line 6b
-        report.form_3x.L6b_cash_on_hand_beginning_period = a["line_6b"]
+        report.form_3x.L6b_cash_on_hand_beginning_period = a.get("line_6b", None)
         # line 6c
         report.form_3x.L6c_total_receipts_period = a.get("line_6c", 0)
         report.form_3x.L6c_total_receipts_ytd = b.get("line_6c", 0)
         # line 6d
-        report.form_3x.L6d_subtotal_period = a.get("line_6d", 0)
-        report.form_3x.L6d_subtotal_ytd = b.get("line_6d", 0)
+        report.form_3x.L6d_subtotal_period = a.get("line_6d", None)
+        report.form_3x.L6d_subtotal_ytd = b.get("line_6d", None)
         # line 7
         report.form_3x.L7_total_disbursements_period = a.get("line_7", 0)
         report.form_3x.L7_total_disbursements_ytd = b.get("line_7", 0)
         # line 8
-        report.form_3x.L8_cash_on_hand_at_close_period = a.get("line_8", 0)
-        report.form_3x.L8_cash_on_hand_close_ytd = b.get("line_8", 0)
+        report.form_3x.L8_cash_on_hand_at_close_period = a.get("line_8", None)
+        report.form_3x.L8_cash_on_hand_close_ytd = b.get("line_8", None)
         # line 9
         report.form_3x.L9_debts_to_period = a.get("line_9", 0)
         # line 10
@@ -86,14 +86,20 @@ def calculate_summary(report_id):
         report.form_3x.L11b_political_party_committees_period = a.get("line_11b", 0)
         report.form_3x.L11b_political_party_committees_ytd = b.get("line_11b", 0)
         # line 11c
-        report.form_3x.L11c_other_political_committees_pacs_period = a.get("line_11c", 0)
+        report.form_3x.L11c_other_political_committees_pacs_period = a.get(
+            "line_11c", 0
+        )
         report.form_3x.L11c_other_political_committees_pacs_ytd = b.get("line_11c", 0)
         # line 11d
         report.form_3x.L11d_total_contributions_period = a.get("line_11d", 0)
         report.form_3x.L11d_total_contributions_ytd = b.get("line_11d", 0)
         # line 12
-        report.form_3x.L12_transfers_from_affiliated_other_party_cmtes_period = a.get("line_12", 0)  # noqa: E501
-        report.form_3x.L12_transfers_from_affiliated_other_party_cmtes_ytd = b.get("line_12", 0)  # noqa: E501
+        report.form_3x.L12_transfers_from_affiliated_other_party_cmtes_period = a.get(
+            "line_12", 0
+        )  # noqa: E501
+        report.form_3x.L12_transfers_from_affiliated_other_party_cmtes_ytd = b.get(
+            "line_12", 0
+        )  # noqa: E501
         # line 13
         report.form_3x.L13_all_loans_received_period = a.get("line_13", 0)
         report.form_3x.L13_all_loans_received_ytd = b.get("line_13", 0)
@@ -101,8 +107,12 @@ def calculate_summary(report_id):
         report.form_3x.L14_loan_repayments_received_period = a.get("line_14", 0)
         report.form_3x.L14_loan_repayments_received_ytd = b.get("line_14", 0)
         # line 15
-        report.form_3x.L15_offsets_to_operating_expenditures_refunds_period = a.get("line_15", 0)  # noqa: E501
-        report.form_3x.L15_offsets_to_operating_expenditures_refunds_ytd = b.get("line_15", 0)  # noqa: E501
+        report.form_3x.L15_offsets_to_operating_expenditures_refunds_period = a.get(
+            "line_15", 0
+        )  # noqa: E501
+        report.form_3x.L15_offsets_to_operating_expenditures_refunds_ytd = b.get(
+            "line_15", 0
+        )  # noqa: E501
         # line 16
         report.form_3x.L16_refunds_of_federal_contributions_period = a.get("line_16", 0)
         report.form_3x.L16_refunds_of_federal_contributions_ytd = b.get("line_16", 0)
@@ -110,14 +120,26 @@ def calculate_summary(report_id):
         report.form_3x.L17_other_federal_receipts_dividends_period = a.get("line_17", 0)
         report.form_3x.L17_other_federal_receipts_dividends_ytd = b.get("line_17", 0)
         # line 18a
-        report.form_3x.L18a_transfers_from_nonfederal_account_h3_period = a.get("line_18a", 0)  # noqa: E501
-        report.form_3x.L18a_transfers_from_nonfederal_account_h3_ytd = b.get("line_18a", 0)  # noqa: E501
+        report.form_3x.L18a_transfers_from_nonfederal_account_h3_period = a.get(
+            "line_18a", 0
+        )  # noqa: E501
+        report.form_3x.L18a_transfers_from_nonfederal_account_h3_ytd = b.get(
+            "line_18a", 0
+        )  # noqa: E501
         # line 18b
-        report.form_3x.L18b_transfers_from_nonfederal_levin_h5_period = a.get("line_18b", 0)  # noqa: E501
-        report.form_3x.L18b_transfers_from_nonfederal_levin_h5_ytd = b.get("line_18b", 0)
+        report.form_3x.L18b_transfers_from_nonfederal_levin_h5_period = a.get(
+            "line_18b", 0
+        )  # noqa: E501
+        report.form_3x.L18b_transfers_from_nonfederal_levin_h5_ytd = b.get(
+            "line_18b", 0
+        )
         # line 18c
-        report.form_3x.L18c_total_nonfederal_transfers_18a_18b_period = a.get("line_18c", 0)  # noqa: E501
-        report.form_3x.L18c_total_nonfederal_transfers_18a_18b_ytd = b.get("line_18c", 0)
+        report.form_3x.L18c_total_nonfederal_transfers_18a_18b_period = a.get(
+            "line_18c", 0
+        )  # noqa: E501
+        report.form_3x.L18c_total_nonfederal_transfers_18a_18b_ytd = b.get(
+            "line_18c", 0
+        )
         # line 19
         report.form_3x.L19_total_receipts_period = a.get("line_19", 0)
         report.form_3x.L19_total_receipts_ytd = b.get("line_19", 0)
@@ -131,23 +153,39 @@ def calculate_summary(report_id):
         report.form_3x.L21aii_nonfederal_share_period = a.get("line_21aii", 0)
         report.form_3x.L21aii_nonfederal_share_ytd = b.get("line_21aii", 0)
         # line 21b
-        report.form_3x.L21b_other_federal_operating_expenditures_period = a.get("line_21b", 0)  # noqa: E501
-        report.form_3x.L21b_other_federal_operating_expenditures_ytd = b.get("line_21b", 0)  # noqa: E501
+        report.form_3x.L21b_other_federal_operating_expenditures_period = a.get(
+            "line_21b", 0
+        )  # noqa: E501
+        report.form_3x.L21b_other_federal_operating_expenditures_ytd = b.get(
+            "line_21b", 0
+        )  # noqa: E501
         # line 21c
         report.form_3x.L21c_total_operating_expenditures_ytd = b.get("line_21c", 0)
         report.form_3x.L21c_total_operating_expenditures_period = a.get("line_21c", 0)
         # line 22
-        report.form_3x.L22_transfers_to_affiliated_other_party_cmtes_period = a.get("line_22", 0)  # noqa: E501
-        report.form_3x.L22_transfers_to_affiliated_other_party_cmtes_ytd = b.get("line_22", 0)  # noqa: E501
+        report.form_3x.L22_transfers_to_affiliated_other_party_cmtes_period = a.get(
+            "line_22", 0
+        )  # noqa: E501
+        report.form_3x.L22_transfers_to_affiliated_other_party_cmtes_ytd = b.get(
+            "line_22", 0
+        )  # noqa: E501
         # line 23
-        report.form_3x.L23_contributions_to_federal_candidates_cmtes_period = a.get("line_23", 0)  # noqa: E501
-        report.form_3x.L23_contributions_to_federal_candidates_cmtes_ytd = b.get("line_23", 0)  # noqa: E501
+        report.form_3x.L23_contributions_to_federal_candidates_cmtes_period = a.get(
+            "line_23", 0
+        )  # noqa: E501
+        report.form_3x.L23_contributions_to_federal_candidates_cmtes_ytd = b.get(
+            "line_23", 0
+        )  # noqa: E501
         # line 24
         report.form_3x.L24_independent_expenditures_period = a.get("line_24", 0)
         report.form_3x.L24_independent_expenditures_ytd = b.get("line_24", 0)
         # line 25
-        report.form_3x.L25_coordinated_expend_made_by_party_cmtes_period = a.get("line_25", 0)  # noqa: E501
-        report.form_3x.L25_coordinated_expend_made_by_party_cmtes_ytd = b.get("line_25", 0)  # noqa: E501
+        report.form_3x.L25_coordinated_expend_made_by_party_cmtes_period = a.get(
+            "line_25", 0
+        )  # noqa: E501
+        report.form_3x.L25_coordinated_expend_made_by_party_cmtes_ytd = b.get(
+            "line_25", 0
+        )  # noqa: E501
         # line 26
         report.form_3x.L26_loan_repayments_period = a.get("line_26", 0)
         report.form_3x.L26_loan_repayments_made_ytd = b.get("line_26", 0)
@@ -170,16 +208,30 @@ def calculate_summary(report_id):
         report.form_3x.L29_other_disbursements_period = a.get("line_29", 0)
         report.form_3x.L29_other_disbursements_ytd = b.get("line_29", 0)
         # line 30ai
-        report.form_3x.L30ai_shared_federal_activity_h6_fed_share_period = a.get("line_30ai", 0)  # noqa: E501
-        report.form_3x.L30ai_shared_federal_activity_h6_fed_share_ytd = b.get("line_30ai", 0)  # noqa: E501
+        report.form_3x.L30ai_shared_federal_activity_h6_fed_share_period = a.get(
+            "line_30ai", 0
+        )  # noqa: E501
+        report.form_3x.L30ai_shared_federal_activity_h6_fed_share_ytd = b.get(
+            "line_30ai", 0
+        )  # noqa: E501
         # line 30aii
-        report.form_3x.L30aii_shared_federal_activity_h6_nonfed_period = a.get("line_30aii", 0)  # noqa: E501
-        report.form_3x.L30aii_shared_federal_activity_h6_nonfed_ytd = b.get("line_30aii", 0)  # noqa: E501
+        report.form_3x.L30aii_shared_federal_activity_h6_nonfed_period = a.get(
+            "line_30aii", 0
+        )  # noqa: E501
+        report.form_3x.L30aii_shared_federal_activity_h6_nonfed_ytd = b.get(
+            "line_30aii", 0
+        )  # noqa: E501
         # line 30b
-        report.form_3x.L30b_nonallocable_fed_election_activity_period = a.get("line_30b", 0)  # noqa: E501
-        report.form_3x.L30b_nonallocable_fed_election_activity_ytd = b.get("line_30b", 0)
+        report.form_3x.L30b_nonallocable_fed_election_activity_period = a.get(
+            "line_30b", 0
+        )  # noqa: E501
+        report.form_3x.L30b_nonallocable_fed_election_activity_ytd = b.get(
+            "line_30b", 0
+        )
         # line 30c
-        report.form_3x.L30c_total_federal_election_activity_period = a.get("line_30c", 0)
+        report.form_3x.L30c_total_federal_election_activity_period = a.get(
+            "line_30c", 0
+        )
         report.form_3x.L30c_total_federal_election_activity_ytd = b.get("line_30c", 0)
         # line 31
         report.form_3x.L31_total_disbursements_period = a.get("line_31", 0)
@@ -197,10 +249,16 @@ def calculate_summary(report_id):
         report.form_3x.L35_net_contributions_period = a.get("line_35", 0)
         report.form_3x.L35_net_contributions_ytd = b.get("line_35", 0)
         # line 36
-        report.form_3x.L36_total_federal_operating_expenditures_period = a.get("line_36", 0)  # noqa: E501
-        report.form_3x.L36_total_federal_operating_expenditures_ytd = b.get("line_36", 0)
+        report.form_3x.L36_total_federal_operating_expenditures_period = a.get(
+            "line_36", 0
+        )  # noqa: E501
+        report.form_3x.L36_total_federal_operating_expenditures_ytd = b.get(
+            "line_36", 0
+        )
         # line 37
-        report.form_3x.L37_offsets_to_operating_expenditures_period = a.get("line_37", 0)
+        report.form_3x.L37_offsets_to_operating_expenditures_period = a.get(
+            "line_37", 0
+        )
         report.form_3x.L37_offsets_to_operating_expenditures_ytd = b.get("line_37", 0)
         # line 38
         report.form_3x.L38_net_operating_expenditures_period = a.get("line_38", 0)
@@ -216,11 +274,9 @@ def calculate_summary(report_id):
         # reports that have been invalidated
         updated = bool(
             Report.objects.filter(
-                id=report.id,
-                calculation_token=calculation_token
+                id=report.id, calculation_token=calculation_token
             ).update(
-                calculation_status=CalculationState.SUCCEEDED,
-                calculation_token=None
+                calculation_status=CalculationState.SUCCEEDED, calculation_token=None
             )
         )
 

--- a/django-backend/fecfiler/web_services/summary/test_summary.py
+++ b/django-backend/fecfiler/web_services/summary/test_summary.py
@@ -20,9 +20,7 @@ class F3XReportTestCase(TestCase):
     def test_calculate_summary_column_a(self):
         f3x = Report.objects.get(id="b6d60d2d-d926-4e89-ad4b-c47d152a66ae")
         summary_service = SummaryService(f3x)
-        summary = summary_service.calculate_summary()
-
-        summary_a = summary["a"]
+        summary_a, _ = summary_service.calculate_summary()
 
         self.assertEqual(summary_a["line_6c"], Decimal("18085.17"))
         self.assertEqual(
@@ -118,9 +116,7 @@ class F3XReportTestCase(TestCase):
     def test_calculate_summary_column_b(self):
         f3x = Report.objects.get(id="b6d60d2d-d926-4e89-ad4b-c47d152a66ae")
         summary_service = SummaryService(f3x)
-        summary = summary_service.calculate_summary()
-
-        summary_b = summary["b"]
+        _, summary_b = summary_service.calculate_summary()
 
         t = Transaction.objects.get(id="aaaaaaaa-4d75-46f0-bce2-111000000001")
         self.assertEqual(t.itemized, False)
@@ -213,6 +209,6 @@ class F3XReportTestCase(TestCase):
     def test_report_with_no_transactions(self):
         f3x = Report.objects.get(id="a07c8c65-1b2d-4e6e-bcaa-fa8d39e50965")
         summary_service = SummaryService(f3x)
-        summary = summary_service.calculate_summary()
-        self.assertEqual(summary["a"]["line_15"], Decimal("0"))
-        self.assertEqual(summary["a"]["line_17"], Decimal("0"))
+        summary_a, _ = summary_service.calculate_summary()
+        self.assertEqual(summary_a["line_15"], Decimal("0"))
+        self.assertEqual(summary_a["line_17"], Decimal("0"))


### PR DESCRIPTION
- filters previous report by committee
- handles cash on hand values outside columns
- sets 6b to 8(column a) of previous report or 6a of the given report (not defaulting to 0 so that it doesn't overwrite user entered cash on hand, even if they haven't entered it)
- sets 6a to 8(column b) of last-report-last-year or 6a of the previous report (which will be the same as the first of the year) or 6a of the given report (not defaulting to 0 so that it doesn't overwrite user entered cash on hand, even if they haven't entered it)
- only set 6d and 8 if 6a and 6b are defined