### PR TITLE
587 - Only build develop docs on develop branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -254,6 +254,9 @@ workflows:
           requires:
             - test
             - dependency-check
+          filters:
+            branches:
+              only: develop
       - docs-deploy:
           requires:
             - docs-build


### PR DESCRIPTION
The developer docs only need to be built when pushing the develop branch