### PR TITLE
feature/1618 e2e circle fix

### DIFF
--- a/Dockerfile-e2e
+++ b/Dockerfile-e2e
@@ -1,15 +1,15 @@
 FROM python:3.10
 ENV PYTHONUNBUFFERED=1
 
-RUN mkdir /opt/nxg_fec
-WORKDIR /opt/nxg_fec
+RUN mkdir /opt/nxg_fec_e2e
+WORKDIR /opt/nxg_fec_e2e
 ADD requirements.txt /opt
-ADD django-backend /opt/nxg_fec/
+ADD django-backend /opt/nxg_fec_e2e/
 RUN pip3 install -r /opt/requirements.txt
 
 RUN mv /etc/localtime /etc/localtime.backup && ln -s /usr/share/zoneinfo/EST5EDT /etc/localtime
 
-RUN useradd nxgu --no-create-home --home /opt/nxg_fec && chown -R nxgu:nxgu /opt/nxg_fec
+RUN useradd nxgu --no-create-home --home /opt/nxg_fec_e2e && chown -R nxgu:nxgu /opt/nxg_fec_e2e
 USER nxgu
 
 EXPOSE 8080


### PR DESCRIPTION
It's not obvious, but the working directory has to be `nxg_fec_e2e` for the e2e tests in the dockerfile.  This is because nxg_fec is already mounted as a volume in docker-compose.yml, but because the remote_docker executor that we're using doesn't support volume mounts (see `setup_remote_docker`), we cannot use it (even though it appears to be there).  Trying to use it causes the container fail nearly silently (although the failed container does have this log entry):
`
python: can't open file '/opt/nxg_fec/wait_for_db.py': [Errno 2] No such file or directory`