### PR TITLE
Patch - Fixes dot fec composition for schedule E transactions

### DIFF
--- a/django-backend/fecfiler/web_services/dot_fec/dot_fec_composer.py
+++ b/django-backend/fecfiler/web_services/dot_fec/dot_fec_composer.py
@@ -150,6 +150,7 @@ def get_schema_name(schedule):
         Schedule.C1.value.value: "SchC1",
         Schedule.C2.value.value: "SchC2",
         Schedule.D.value.value: "SchD",
+        Schedule.E.value.value: "SchE"
     }.get(schedule)
 
 

--- a/django-backend/fecfiler/web_services/dot_fec/schema_fields/SchE.json
+++ b/django-backend/fecfiler/web_services/dot_fec/schema_fields/SchE.json
@@ -2,6 +2,8 @@
     "form_type": {},
     "filer_committee_id_number": {},
     "transaction_id": {},
+    "back_reference_tran_id_number": {},
+    "back_reference_sched_name": {},
     "receipt_line_number": {
         "path": "schedule_e.receipt_line_number"
     },
@@ -81,7 +83,7 @@
     "so_candidate_first_name": {
         "path": "schedule_e.so_candidate_first_name"
     },
-    "so_candinate_middle_name": {
+    "so_candidate_middle_name": {
         "path": "schedule_e.so_candidate_middle_name"
     },
     "so_candidate_prefix": {
@@ -121,7 +123,7 @@
     "memo_code": {
         "path": "schedule_e.memo_code"
     },
-    "memo_text/description": {
+    "memo_text_description": {
         "path": "schedule_e.memo_text_description"
     }
 


### PR DESCRIPTION
When generating a .FEC file for a report that _only_ has Schedule E transactions, the process would crash.  This was happening because of a combination of a couple of missing definitions and a typo.