### PR TITLE
[WIP] 651 - Add structlog for json logging in prod

### DIFF
--- a/django-backend/fecfiler/authentication/views.py
+++ b/django-backend/fecfiler/authentication/views.py
@@ -28,9 +28,9 @@ from .serializers import AccountSerializer
 from urllib.parse import urlencode
 from datetime import datetime
 from django.http import JsonResponse
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class AccountViewSet(GenericViewSet, ListModelMixin):

--- a/django-backend/fecfiler/celery.py
+++ b/django-backend/fecfiler/celery.py
@@ -2,7 +2,12 @@ from enum import Enum
 import os
 import ssl
 import cfenv
+import logging
+import structlog
+from django.conf import settings
 from celery import Celery
+from celery.signals import setup_logging
+from django_structlog.celery.steps import DjangoStructLogInitStep
 
 # Set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "fecfiler.settings")
@@ -15,8 +20,72 @@ app = Celery("fecfiler")
 #   should have a `CELERY_` prefix.
 app.config_from_object("django.conf:settings", namespace="CELERY")
 
+# A step to initialize django-structlog
+app.steps['worker'].add(DjangoStructLogInitStep)
 
 env = cfenv.AppEnv()
+
+
+@setup_logging.connect
+def receiver_setup_logging(loglevel, logfile, format, colorize, **kwargs):
+    """
+    Celery and environment-specific logging
+    See https://django-structlog.readthedocs.io/en/latest/celery.html
+    """
+    if env.space is not None:  # Running in prod
+        loggers = settings.PROD_LOGGERS
+        logger_processors = settings.get_prod_logger_processors
+    else:
+        loggers = settings.LOCAL_LOGGERS
+        logger_processors = settings.get_local_logger_processors
+
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "json_formatter": {
+                    "()": structlog.stdlib.ProcessorFormatter,
+                    "processor": structlog.processors.JSONRenderer(),
+                },
+                "plain_console": {
+                    "()": structlog.stdlib.ProcessorFormatter,
+                    "processor": structlog.dev.ConsoleRenderer(),
+                },
+                "key_value": {
+                    "()": structlog.stdlib.ProcessorFormatter,
+                    "processor": structlog.processors.KeyValueRenderer(
+                        key_order=['timestamp', 'level', 'event', 'logger']
+                    ),
+                },
+            },
+            "handlers": {
+                "console": {
+                    "class": "logging.StreamHandler",
+                    "formatter": "plain_console",
+                },
+                "json_file": {
+                    "class": "logging.handlers.WatchedFileHandler",
+                    "filename": "logs/json.log",
+                    "formatter": "json_formatter",
+                },
+                "flat_line_file": {
+                    "class": "logging.handlers.WatchedFileHandler",
+                    "filename": "logs/flat_line.log",
+                    "formatter": "key_value",
+                },
+            },
+            "loggers": loggers
+        }
+    )
+
+    structlog.configure(  # noqa
+        processors=logger_processors(),
+        logger_factory=structlog.stdlib.LoggerFactory(),  # noqa
+        cache_logger_on_first_use=True,
+    )
+
+
 if env.get_service(name="fecfile-api-redis"):
     app.conf["broker_use_ssl"] = {"ssl_cert_reqs": ssl.CERT_NONE}
     app.conf["redis_backend_use_ssl"] = {"ssl_cert_reqs": ssl.CERT_NONE}

--- a/django-backend/fecfiler/committee_accounts/serializers.py
+++ b/django-backend/fecfiler/committee_accounts/serializers.py
@@ -1,8 +1,8 @@
 from fecfiler.committee_accounts.models import CommitteeAccount
 from rest_framework import serializers, relations
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class CommitteeOwnedSerializer(serializers.ModelSerializer):

--- a/django-backend/fecfiler/committee_accounts/signals.py
+++ b/django-backend/fecfiler/committee_accounts/signals.py
@@ -9,9 +9,9 @@ We use signals to log saves to be consistent with delete logging
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 from .models import CommitteeAccount
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 @receiver(post_save, sender=CommitteeAccount)

--- a/django-backend/fecfiler/committee_accounts/views.py
+++ b/django-backend/fecfiler/committee_accounts/views.py
@@ -12,4 +12,7 @@ class CommitteeOwnedViewSet(viewsets.ModelViewSet):
     def get_queryset(self):
         committee_id = self.request.user.cmtee_id
         queryset = super().get_queryset()
+        structlog.contextvars.bind_contextvars(
+            committee_id=self.request.user.cmtee_id
+        )
         return queryset.filter(committee_account__committee_id=committee_id)

--- a/django-backend/fecfiler/committee_accounts/views.py
+++ b/django-backend/fecfiler/committee_accounts/views.py
@@ -1,7 +1,7 @@
 from rest_framework import viewsets
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class CommitteeOwnedViewSet(viewsets.ModelViewSet):

--- a/django-backend/fecfiler/contacts/serializers.py
+++ b/django-backend/fecfiler/contacts/serializers.py
@@ -1,4 +1,4 @@
-import logging
+import structlog
 
 from django.db import transaction
 from django.db.models import Q
@@ -13,7 +13,7 @@ from rest_framework.exceptions import ValidationError
 
 from .models import Contact
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class ContactSerializer(

--- a/django-backend/fecfiler/contacts/signals.py
+++ b/django-backend/fecfiler/contacts/signals.py
@@ -9,9 +9,9 @@ We use signals to log saves to be consistent with delete logging
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 from .models import Contact
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 @receiver(post_save, sender=Contact)

--- a/django-backend/fecfiler/contacts/signals.py
+++ b/django-backend/fecfiler/contacts/signals.py
@@ -21,9 +21,12 @@ def log_post_save(sender, instance, created, **kwargs):
         action = "created"
     elif instance.deleted:
         action = "deleted"
-    logger.info("Contact: %s was %s", str(instance), action)
+    logger.info(
+        f"Contact {action}",
+        contact_id=instance.id
+    )
 
 
 @receiver(post_delete, sender=Contact)
 def log_post_delete(sender, instance, **kwargs):
-    logger.info("Contact: %s was deleted", str(instance))
+    logger.info("Contact deleted", contact_id=instance.id)

--- a/django-backend/fecfiler/contacts/views.py
+++ b/django-backend/fecfiler/contacts/views.py
@@ -1,4 +1,5 @@
-import logging
+import structlog
+
 import re
 from urllib.parse import urlencode
 from django.db import transaction
@@ -22,7 +23,7 @@ from rest_framework.viewsets import mixins, GenericViewSet
 from .models import Contact
 from .serializers import ContactSerializer
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 default_max_fec_results = 10
 default_max_fecfile_results = 10

--- a/django-backend/fecfiler/f3x_summaries/models.py
+++ b/django-backend/fecfiler/f3x_summaries/models.py
@@ -5,11 +5,10 @@ from django.db.models import Q
 from fecfiler.soft_delete.models import SoftDeleteModel
 from fecfiler.committee_accounts.models import CommitteeOwnedModel
 from decimal import Decimal
-import logging
 import copy
+import structlog
 
-
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class F3XSummary(SoftDeleteModel, CommitteeOwnedModel):

--- a/django-backend/fecfiler/f3x_summaries/serializers.py
+++ b/django-backend/fecfiler/f3x_summaries/serializers.py
@@ -7,13 +7,13 @@ from fecfiler.web_services.serializers import (
     WebPrintSubmissionSerializer,
 )
 from fecfiler.validation.serializers import FecSchemaValidatorSerializerMixin
-import logging
+import structlog
+
 
 COVERAGE_DATE_REPORT_CODE_COLLISION = ValidationError(
     {"report_code": ["Collision with existing report_code and year"]}
 )
-
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class F3XSummarySerializer(CommitteeOwnedSerializer, FecSchemaValidatorSerializerMixin):

--- a/django-backend/fecfiler/f3x_summaries/signals.py
+++ b/django-backend/fecfiler/f3x_summaries/signals.py
@@ -9,9 +9,9 @@ We use signals to log saves to be consistent with delete logging
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 from .models import F3XSummary
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 @receiver(post_save, sender=F3XSummary)

--- a/django-backend/fecfiler/f3x_summaries/views.py
+++ b/django-backend/fecfiler/f3x_summaries/views.py
@@ -12,9 +12,9 @@ from fecfiler.memo_text.models import MemoText
 from fecfiler.web_services.models import DotFEC, UploadSubmission, WebPrintSubmission
 from .serializers import F3XSummarySerializer
 from django.db.models import Case, Value, When, Q
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def get_status_mapping():

--- a/django-backend/fecfiler/memo_text/models.py
+++ b/django-backend/fecfiler/memo_text/models.py
@@ -4,10 +4,9 @@ from fecfiler.reports.models import ReportMixin
 from fecfiler.shared.utilities import generate_fec_uid
 from django.db import models
 import uuid
-import logging
+import structlog
 
-
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class MemoText(SoftDeleteModel, CommitteeOwnedModel, ReportMixin):

--- a/django-backend/fecfiler/memo_text/serializers.py
+++ b/django-backend/fecfiler/memo_text/serializers.py
@@ -3,9 +3,9 @@ from django.db import transaction
 from fecfiler.validation import serializers
 from rest_framework.serializers import UUIDField, ModelSerializer
 from fecfiler.committee_accounts.serializers import CommitteeOwnedSerializer
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class MemoTextSerializer(

--- a/django-backend/fecfiler/memo_text/signals.py
+++ b/django-backend/fecfiler/memo_text/signals.py
@@ -9,9 +9,9 @@ We use signals to log saves to be consistent with delete logging
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 from .models import MemoText
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 @receiver(post_save, sender=MemoText)

--- a/django-backend/fecfiler/openfec/views.py
+++ b/django-backend/fecfiler/openfec/views.py
@@ -7,9 +7,9 @@ from fecfiler.settings import base
 
 import os
 import json
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class OpenfecViewSet(viewsets.ModelViewSet):

--- a/django-backend/fecfiler/reports/form_1m/models.py
+++ b/django-backend/fecfiler/reports/form_1m/models.py
@@ -1,9 +1,8 @@
 import uuid
 from django.db import models
-import logging
+import structlog
 
-
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class Form1M(models.Model):

--- a/django-backend/fecfiler/reports/form_1m/serializers.py
+++ b/django-backend/fecfiler/reports/form_1m/serializers.py
@@ -4,10 +4,9 @@ from fecfiler.reports.form_1m.models import Form1M
 from fecfiler.reports.serializers import ReportSerializer
 from fecfiler.shared.utilities import get_model_data
 from rest_framework.serializers import CharField, DateField
-import logging
+import structlog
 
-
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class Form1MSerializer(ReportSerializer):

--- a/django-backend/fecfiler/reports/form_1m/views.py
+++ b/django-backend/fecfiler/reports/form_1m/views.py
@@ -3,9 +3,9 @@ from fecfiler.reports.models import Report
 from fecfiler.reports.managers import ReportType
 from fecfiler.reports.views import ReportViewSet
 from .serializers import Form1MSerializer
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class Form1MViewSet(ReportViewSet):

--- a/django-backend/fecfiler/reports/form_24/models.py
+++ b/django-backend/fecfiler/reports/form_24/models.py
@@ -1,9 +1,8 @@
 import uuid
 from django.db import models
-import logging
+import structlog
 
-
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class Form24(models.Model):

--- a/django-backend/fecfiler/reports/form_24/serializers.py
+++ b/django-backend/fecfiler/reports/form_24/serializers.py
@@ -7,10 +7,9 @@ from rest_framework.serializers import (
     CharField,
     DateField,
 )
-import logging
+import structlog
 
-
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class Form24Serializer(ReportSerializer):

--- a/django-backend/fecfiler/reports/form_24/views.py
+++ b/django-backend/fecfiler/reports/form_24/views.py
@@ -3,9 +3,9 @@ from fecfiler.reports.models import Report
 from fecfiler.reports.managers import ReportType
 from fecfiler.reports.views import ReportViewSet
 from .serializers import Form24Serializer
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class Form24ViewSet(ReportViewSet):

--- a/django-backend/fecfiler/reports/form_3x/models.py
+++ b/django-backend/fecfiler/reports/form_3x/models.py
@@ -1,9 +1,8 @@
 import uuid
 from django.db import models
-import logging
+import structlog
 
-
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class Form3X(models.Model):

--- a/django-backend/fecfiler/reports/form_3x/serializers.py
+++ b/django-backend/fecfiler/reports/form_3x/serializers.py
@@ -11,13 +11,13 @@ from rest_framework.serializers import (
     DateField,
     BooleanField,
 )
-import logging
+import structlog
+
+logger = structlog.get_logger(__name__)
 
 COVERAGE_DATE_REPORT_CODE_COLLISION = ValidationError(
     {"report_code": ["Collision with existing report_code and year"]}
 )
-
-logger = logging.getLogger(__name__)
 
 
 class Form3XSerializer(ReportSerializer):

--- a/django-backend/fecfiler/reports/form_3x/views.py
+++ b/django-backend/fecfiler/reports/form_3x/views.py
@@ -5,9 +5,9 @@ from fecfiler.reports.models import Report
 from fecfiler.reports.managers import ReportType
 from fecfiler.reports.views import ReportViewSet
 from .serializers import Form3XSerializer
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class Form3XViewSet(ReportViewSet):

--- a/django-backend/fecfiler/reports/form_99/models.py
+++ b/django-backend/fecfiler/reports/form_99/models.py
@@ -1,9 +1,8 @@
 import uuid
 from django.db import models
-import logging
+import structlog
 
-
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class Form99(models.Model):

--- a/django-backend/fecfiler/reports/form_99/serializers.py
+++ b/django-backend/fecfiler/reports/form_99/serializers.py
@@ -4,10 +4,9 @@ from fecfiler.reports.form_99.models import Form99
 from fecfiler.reports.serializers import ReportSerializer
 from fecfiler.shared.utilities import get_model_data
 from rest_framework.serializers import CharField
-import logging
+import structlog
 
-
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class Form99Serializer(ReportSerializer):

--- a/django-backend/fecfiler/reports/form_99/views.py
+++ b/django-backend/fecfiler/reports/form_99/views.py
@@ -3,9 +3,9 @@ from fecfiler.reports.models import Report
 from fecfiler.reports.managers import ReportType
 from fecfiler.reports.views import ReportViewSet
 from .serializers import Form99Serializer
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class Form99ViewSet(ReportViewSet):

--- a/django-backend/fecfiler/reports/models.py
+++ b/django-backend/fecfiler/reports/models.py
@@ -10,10 +10,9 @@ from .form_3x.models import Form3X
 from .form_24.models import Form24
 from .form_99.models import Form99
 from .form_1m.models import Form1M
-import logging
+import structlog
 
-
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class Report(SoftDeleteModel, CommitteeOwnedModel):

--- a/django-backend/fecfiler/reports/serializers.py
+++ b/django-backend/fecfiler/reports/serializers.py
@@ -15,10 +15,9 @@ from fecfiler.reports.form_3x.models import Form3X
 from fecfiler.reports.form_24.models import Form24
 from fecfiler.reports.form_99.models import Form99
 from fecfiler.reports.form_1m.models import Form1M
-import logging
+import structlog
 
-
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class Form3XSerializer(ModelSerializer):

--- a/django-backend/fecfiler/reports/signals.py
+++ b/django-backend/fecfiler/reports/signals.py
@@ -9,9 +9,9 @@ We use signals to log saves to be consistent with delete logging
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 from .models import Report
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 @receiver(post_save, sender=Report)

--- a/django-backend/fecfiler/reports/views.py
+++ b/django-backend/fecfiler/reports/views.py
@@ -10,9 +10,9 @@ from fecfiler.memo_text.models import MemoText
 from fecfiler.web_services.models import DotFEC, UploadSubmission, WebPrintSubmission
 from .serializers import ReportSerializer
 from django.db.models import Case, Value, When, Q, CharField
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 report_code_label_mapping = Case(
     When(report_code="Q1", then=Value("APRIL 15 (Q1)")),

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -207,7 +207,6 @@ REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 10,
-    "EXCEPTION_HANDLER": "fecfiler.utils.custom_exception_handler",
 }
 
 
@@ -222,7 +221,10 @@ def get_env_logging_config(prod=False):
             },
             "plain_console": {
                 "()": structlog.stdlib.ProcessorFormatter,
-                "processor": structlog.dev.ConsoleRenderer(),
+                "processor": structlog.dev.ConsoleRenderer(
+                    colors=True,
+                    exception_formatter=structlog.dev.rich_traceback
+                ),
             },
             "key_value": {
                 "()": structlog.stdlib.ProcessorFormatter,
@@ -279,6 +281,7 @@ def get_env_logging_processors(prod=False):
     """
 
     if prod:
+        # JSON in production
         return [
             structlog.contextvars.merge_contextvars,
             structlog.stdlib.filter_by_level,
@@ -287,10 +290,8 @@ def get_env_logging_processors(prod=False):
             structlog.stdlib.add_log_level,
             structlog.stdlib.PositionalArgumentsFormatter(),
             structlog.processors.StackInfoRenderer(),
-            structlog.processors.format_exc_info,
             structlog.processors.UnicodeDecoder(),
             structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
-            # JSON in production
             structlog.processors.JSONRenderer(),
         ]
     else:
@@ -302,7 +303,6 @@ def get_env_logging_processors(prod=False):
             structlog.stdlib.add_log_level,
             structlog.stdlib.PositionalArgumentsFormatter(),
             structlog.processors.StackInfoRenderer(),
-            structlog.processors.format_exc_info,
             structlog.processors.UnicodeDecoder(),
             structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
         ]

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -210,112 +210,107 @@ REST_FRAMEWORK = {
     "EXCEPTION_HANDLER": "fecfiler.utils.custom_exception_handler",
 }
 
-LOCAL_LOGGERS = {
-    "django_structlog": {
-        "handlers": ["console"],
-        "level": "DEBUG",
-    },
-    "fecfiler": {
-        "handlers": ["console"],
-        "level": "DEBUG",
-    },
-}
 
-# We will need to set these explicitly for Celery too
-PROD_LOGGERS = {
-    "django_structlog": {
-        "handlers": ["cloud"],
-        "level": "INFO",
-    },
-    "fecfiler": {
-        "handlers": ["cloud"],
-        "level": "INFO",
-    },
-}
+def get_env_logging_config(prod=False):
+    logging_config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "json_formatter": {
+                "()": structlog.stdlib.ProcessorFormatter,
+                "processor": structlog.processors.JSONRenderer(),
+            },
+            "plain_console": {
+                "()": structlog.stdlib.ProcessorFormatter,
+                "processor": structlog.dev.ConsoleRenderer(),
+            },
+            "key_value": {
+                "()": structlog.stdlib.ProcessorFormatter,
+                "processor": structlog.processors.KeyValueRenderer(
+                    key_order=['timestamp', 'level', 'event', 'logger']
+                ),
+            },
+        },
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "formatter": "plain_console",
+            },
+            "cloud": {
+                "class": "logging.StreamHandler",
+                "formatter": "json_formatter",
+            },
+        }
+    }
+
+    if prod:
+        logging_config["loggers"] = {
+            "django_structlog": {
+                "handlers": ["cloud"],
+                "level": "INFO",
+            },
+            "fecfiler": {
+                "handlers": ["cloud"],
+                "level": "INFO",
+            },
+        }
+    else:
+        logging_config["loggers"] = {
+            "django_structlog": {
+                "handlers": ["console"],
+                "level": "DEBUG",
+            },
+            "fecfiler": {
+                "handlers": ["console"],
+                "level": "DEBUG",
+            },
+        }
+
+    return logging_config
 
 
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "json_formatter": {
-            "()": structlog.stdlib.ProcessorFormatter,
-            "processor": structlog.processors.JSONRenderer(),
-        },
-        "plain_console": {
-            "()": structlog.stdlib.ProcessorFormatter,
-            "processor": structlog.dev.ConsoleRenderer(),
-        },
-        "key_value": {
-            "()": structlog.stdlib.ProcessorFormatter,
-            "processor": structlog.processors.KeyValueRenderer(
-                key_order=['timestamp', 'level', 'event', 'logger']
-            ),
-        },
-    },
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-            "formatter": "plain_console",
-        },
-        "cloud": {
-            "class": "logging.StreamHandler",
-            "formatter": "json_formatter",
-        },
-    },
-    "loggers": LOCAL_LOGGERS
-}
+def get_env_logging_processors(prod=False):
+    """
+    get logger setup, base logging config, and structlog processors
+    depending on environment
+    env.space will None on local.
+
+    We will need to set these explicitly for Celery too
+    """
+
+    if prod:
+        return [
+            structlog.contextvars.merge_contextvars,
+            structlog.stdlib.filter_by_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.UnicodeDecoder(),
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+            # JSON in production
+            structlog.processors.JSONRenderer(),
+        ]
+    else:
+        return [
+            structlog.contextvars.merge_contextvars,
+            structlog.stdlib.filter_by_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.UnicodeDecoder(),
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ]
+
+
+LOGGING = get_env_logging_config()
 
 DJANGO_STRUCTLOG_CELERY_ENABLED = True
-
-# Helper functions so these don't get evaluated until we need them
-# need to set them explicitly for Celery too
-
-
-def get_local_logger_processors():
-    """
-    Formatted console logs
-    from https://github.com/jrobichaud/django-structlog?tab=readme-ov-file#installation
-    see also
-    https://www.structlog.org/en/stable/api.html#structlog.stdlib.ProcessorFormatter
-    """
-    return [
-        structlog.contextvars.merge_contextvars,
-        structlog.stdlib.filter_by_level,
-        structlog.processors.TimeStamper(fmt="iso"),
-        structlog.stdlib.add_logger_name,
-        structlog.stdlib.add_log_level,
-        structlog.stdlib.PositionalArgumentsFormatter(),
-        structlog.processors.StackInfoRenderer(),
-        structlog.processors.format_exc_info,
-        structlog.processors.UnicodeDecoder(),
-        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
-    ]
-
-
-def get_prod_logger_processors():
-    """
-    JSON output configuration
-    From https://www.structlog.org/en/stable/api.html#structlog.processors.JSONRenderer
-
-    structlog.processors.dict_tracebacks is recommended, but we do custom exception
-    handling ("EXCEPTION_HANDLER": "fecfiler.utils.custom_exception_handler" above)
-    """
-    return [
-        structlog.contextvars.merge_contextvars,
-        structlog.stdlib.filter_by_level,
-        structlog.processors.TimeStamper(fmt="iso"),
-        structlog.stdlib.add_logger_name,
-        structlog.stdlib.add_log_level,
-        structlog.stdlib.PositionalArgumentsFormatter(),
-        structlog.processors.StackInfoRenderer(),
-        structlog.processors.format_exc_info,
-        structlog.processors.UnicodeDecoder(),
-        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
-        # JSON in production
-        structlog.processors.JSONRenderer(),
-    ]
-
 
 """Celery configurations
 """

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -207,7 +207,6 @@ REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "PAGE_SIZE": 10,
-    # TODO: Take a look at this
     "EXCEPTION_HANDLER": "fecfiler.utils.custom_exception_handler",
 }
 
@@ -265,7 +264,6 @@ LOGGING = {
         },
     },
     "loggers": LOCAL_LOGGERS
-    # Use "loggers":PROD_LOGGERS to test json logs
 }
 
 DJANGO_STRUCTLOG_CELERY_ENABLED = True
@@ -299,6 +297,9 @@ def get_prod_logger_processors():
     """
     JSON output configuration
     From https://www.structlog.org/en/stable/api.html#structlog.processors.JSONRenderer
+
+    structlog.processors.dict_tracebacks is recommended, but we do custom exception
+    handling ("EXCEPTION_HANDLER": "fecfiler.utils.custom_exception_handler" above)
     """
     return [
         structlog.contextvars.merge_contextvars,
@@ -312,7 +313,6 @@ def get_prod_logger_processors():
         structlog.processors.UnicodeDecoder(),
         structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
         # JSON in production
-        structlog.processors.dict_tracebacks,  # exception handling
         structlog.processors.JSONRenderer(),
     ]
 

--- a/django-backend/fecfiler/settings/e2e.py
+++ b/django-backend/fecfiler/settings/e2e.py
@@ -3,7 +3,6 @@ import os
 
 # These settings are for local development only.
 
-# TODO: Leave as-is?
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/django-backend/fecfiler/settings/e2e.py
+++ b/django-backend/fecfiler/settings/e2e.py
@@ -3,6 +3,7 @@ import os
 
 # These settings are for local development only.
 
+# TODO: Leave as-is?
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/django-backend/fecfiler/settings/local.py
+++ b/django-backend/fecfiler/settings/local.py
@@ -2,22 +2,16 @@ from .base import *  # NOSONAR # noqa F401, F403
 
 # These settings are for local development only.
 
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "formatters": {
-        "standard": {"format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s"},
-    },
-    "handlers": {
-        "default": {
-            "class": "logging.StreamHandler",
-            "formatter": "standard",
-        },
-    },
-    "loggers": {
-        "": {"handlers": ["default"], "level": "DEBUG", "propagate": True},
-    },
-}
+LOGGER_PROCESSORS = get_local_logger_processors()  # noqa
+
+# To test json locally,
+# Set LOGGER_PROCESSORS to get_prod_logger_processors() above
+
+structlog.configure(  # noqa
+    processors=LOGGER_PROCESSORS,
+    logger_factory=structlog.stdlib.LoggerFactory(),  # noqa
+    cache_logger_on_first_use=True,
+)
 
 # E2E Testing Login API
 E2E_TESTING_LOGIN = True

--- a/django-backend/fecfiler/settings/local.py
+++ b/django-backend/fecfiler/settings/local.py
@@ -2,13 +2,8 @@ from .base import *  # NOSONAR # noqa F401, F403
 
 # These settings are for local development only.
 
-LOGGER_PROCESSORS = get_local_logger_processors()  # noqa
-
-# To test json locally,
-# Set LOGGER_PROCESSORS to get_prod_logger_processors() above
-
 structlog.configure(  # noqa
-    processors=LOGGER_PROCESSORS,
+    processors=get_local_logger_processors(), # noqa
     logger_factory=structlog.stdlib.LoggerFactory(),  # noqa
     cache_logger_on_first_use=True,
 )

--- a/django-backend/fecfiler/settings/local.py
+++ b/django-backend/fecfiler/settings/local.py
@@ -3,7 +3,7 @@ from .base import *  # NOSONAR # noqa F401, F403
 # These settings are for local development only.
 
 structlog.configure(  # noqa
-    processors=get_local_logger_processors(), # noqa
+    processors=get_env_logging_processors(), # noqa
     logger_factory=structlog.stdlib.LoggerFactory(),  # noqa
     cache_logger_on_first_use=True,
 )

--- a/django-backend/fecfiler/settings/production.py
+++ b/django-backend/fecfiler/settings/production.py
@@ -7,6 +7,14 @@ from .base import *  # NOSONAR # noqa F401, F403
 DEBUG = False
 TEMPLATE_DEBUG = False
 
+LOGGING['loggers'].update(PROD_LOGGERS) # noqa
+
+structlog.configure(  # noqa
+    processors=get_prod_logger_processors(),  # noqa
+    logger_factory=structlog.stdlib.LoggerFactory(),  # noqa
+    cache_logger_on_first_use=True,
+)
+
 SESSION_COOKIE_SECURE = True
 SESSION_COOKIE_HTTPONLY = True
 CSRF_COOKIE_SECURE = True

--- a/django-backend/fecfiler/settings/production.py
+++ b/django-backend/fecfiler/settings/production.py
@@ -7,10 +7,10 @@ from .base import *  # NOSONAR # noqa F401, F403
 DEBUG = False
 TEMPLATE_DEBUG = False
 
-LOGGING['loggers'].update(PROD_LOGGERS) # noqa
+LOGGING = get_env_logging_config(prod=True) # noqa
 
 structlog.configure(  # noqa
-    processors=get_prod_logger_processors(),  # noqa
+    processors=get_env_logging_processors(prod=True),  # noqa
     logger_factory=structlog.stdlib.LoggerFactory(),  # noqa
     cache_logger_on_first_use=True,
 )

--- a/django-backend/fecfiler/settings/production.py
+++ b/django-backend/fecfiler/settings/production.py
@@ -15,6 +15,9 @@ structlog.configure(  # noqa
     cache_logger_on_first_use=True,
 )
 
+# TODO: I think this is swallowing exceptions
+REST_FRAMEWORK["EXCEPTION_HANDLER"] = "fecfiler.utils.custom_exception_handler"  # noqa
+
 SESSION_COOKIE_SECURE = True
 SESSION_COOKIE_HTTPONLY = True
 CSRF_COOKIE_SECURE = True

--- a/django-backend/fecfiler/transactions/models.py
+++ b/django-backend/fecfiler/transactions/models.py
@@ -12,10 +12,9 @@ from fecfiler.transactions.schedule_c2.models import ScheduleC2
 from fecfiler.transactions.schedule_d.models import ScheduleD
 from fecfiler.transactions.schedule_e.models import ScheduleE
 import uuid
-import logging
+import structlog
 
-
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class Transaction(SoftDeleteModel, CommitteeOwnedModel, ReportMixin):

--- a/django-backend/fecfiler/transactions/serializers.py
+++ b/django-backend/fecfiler/transactions/serializers.py
@@ -1,5 +1,3 @@
-import logging
-
 from django.db.models import Sum
 from fecfiler.committee_accounts.serializers import CommitteeOwnedSerializer
 from fecfiler.contacts.serializers import LinkedContactSerializerMixin
@@ -25,9 +23,10 @@ from fecfiler.transactions.schedule_c1.models import ScheduleC1
 from fecfiler.transactions.schedule_c2.models import ScheduleC2
 from fecfiler.transactions.schedule_d.models import ScheduleD
 from fecfiler.transactions.schedule_e.models import ScheduleE
+import structlog
 
+logger = structlog.get_logger(__name__)
 
-logger = logging.getLogger(__name__)
 MISSING_SCHEMA_NAME_ERROR = ValidationError(
     {"schema_name": ["No schema_name provided"]}
 )

--- a/django-backend/fecfiler/transactions/signals.py
+++ b/django-backend/fecfiler/transactions/signals.py
@@ -9,9 +9,9 @@ We use signals to log saves to be consistent with delete logging
 from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 from .models import Transaction
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 @receiver(post_save, sender=Transaction)

--- a/django-backend/fecfiler/transactions/views.py
+++ b/django-backend/fecfiler/transactions/views.py
@@ -1,4 +1,3 @@
-import logging
 from django.db import transaction as db_transaction
 from rest_framework import filters, pagination
 from rest_framework.decorators import action
@@ -19,8 +18,9 @@ from fecfiler.contacts.models import Contact
 from fecfiler.transactions.schedule_c.views import save_hook as schedule_c_save_hook
 from fecfiler.transactions.schedule_c2.views import save_hook as schedule_c2_save_hook
 from fecfiler.transactions.schedule_d.views import save_hook as schedule_d_save_hook
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class TransactionListPagination(pagination.PageNumberPagination):

--- a/django-backend/fecfiler/validation/serializers.py
+++ b/django-backend/fecfiler/validation/serializers.py
@@ -5,9 +5,10 @@ from rest_framework import exceptions
 from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import CharField, ListField
 from functools import reduce
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
+
 MISSING_SCHEMA_NAME_ERROR = ValidationError(
     {"schema_name": ["No schema_name provided"]}
 )

--- a/django-backend/fecfiler/web_services/dot_fec/dot_fec_composer.py
+++ b/django-backend/fecfiler/web_services/dot_fec/dot_fec_composer.py
@@ -6,10 +6,9 @@ from fecfiler.transactions.managers import Schedule
 from django.core.exceptions import ObjectDoesNotExist
 from .dot_fec_serializer import serialize_instance, CRLF_STR
 from fecfiler.settings import FILE_AS_TEST_COMMITTEE, OUTPUT_TEST_INFO_IN_DOT_FEC
+import structlog
 
-import logging
-
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def compose_report(report_id, upload_submission_record_id):

--- a/django-backend/fecfiler/web_services/dot_fec/dot_fec_serializer.py
+++ b/django-backend/fecfiler/web_services/dot_fec/dot_fec_serializer.py
@@ -4,9 +4,9 @@ from curses import ascii
 import os
 import json
 
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 CRLF_STR = str(chr(ascii.CR) + chr(ascii.LF))
 FS_STR = chr(ascii.FS)

--- a/django-backend/fecfiler/web_services/dot_fec/dot_fec_submitter.py
+++ b/django-backend/fecfiler/web_services/dot_fec/dot_fec_submitter.py
@@ -9,10 +9,9 @@ from fecfiler.settings import (
     TEST_COMMITTEE_PASSWORD,
     FEC_AGENCY_ID,
 )
+import structlog
 
-import logging
-
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class DotFECSubmitter:

--- a/django-backend/fecfiler/web_services/dot_fec/web_print_submitter.py
+++ b/django-backend/fecfiler/web_services/dot_fec/web_print_submitter.py
@@ -4,9 +4,9 @@ from zeep import Client
 from fecfiler.web_services.models import FECStatus
 from fecfiler.settings import FEC_FILING_API_KEY
 
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class WebPrintSubmitter:

--- a/django-backend/fecfiler/web_services/models.py
+++ b/django-backend/fecfiler/web_services/models.py
@@ -3,9 +3,9 @@ import json
 import uuid
 from django.db import models
 from fecfiler.reports.models import Report, ReportMixin
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class DotFEC(ReportMixin):

--- a/django-backend/fecfiler/web_services/summary/summary.py
+++ b/django-backend/fecfiler/web_services/summary/summary.py
@@ -3,9 +3,9 @@ from fecfiler.transactions.models import Transaction
 from fecfiler.reports.models import Report
 from django.db.models import Q, Sum
 from django.db.models.functions import Coalesce
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class SummaryService:

--- a/django-backend/fecfiler/web_services/summary/tasks.py
+++ b/django-backend/fecfiler/web_services/summary/tasks.py
@@ -4,10 +4,9 @@ from fecfiler.reports.models import Report
 from django.db.models import Q
 from .summary import SummaryService
 import uuid
+import structlog
 
-import logging
-
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class CalculationState(Enum):

--- a/django-backend/fecfiler/web_services/summary/views.py
+++ b/django-backend/fecfiler/web_services/summary/views.py
@@ -5,9 +5,9 @@ from rest_framework.decorators import action
 from .tasks import calculate_summary, CalculationState
 from ..serializers import ReportIdSerializer
 
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class SummaryViewSet(viewsets.ViewSet):

--- a/django-backend/fecfiler/web_services/tasks.py
+++ b/django-backend/fecfiler/web_services/tasks.py
@@ -15,9 +15,9 @@ from fecfiler.web_services.dot_fec.web_print_submitter import WebPrintSubmitter
 from .web_service_storage import get_file_bytes, store_file
 from fecfiler.settings import WEBPRINT_EMAIL, FEC_FILING_API
 
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 @shared_task

--- a/django-backend/fecfiler/web_services/views.py
+++ b/django-backend/fecfiler/web_services/views.py
@@ -12,10 +12,9 @@ from .serializers import ReportIdSerializer, SubmissionRequestSerializer
 from .renderers import DotFECRenderer
 from .web_service_storage import get_file
 from .models import DotFEC, UploadSubmission, WebPrintSubmission
+import structlog
 
-import logging
-
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class WebServicesViewSet(viewsets.ViewSet):

--- a/django-backend/fecfiler/web_services/web_service_storage.py
+++ b/django-backend/fecfiler/web_services/web_service_storage.py
@@ -6,9 +6,9 @@ from fecfiler.settings import (
 )
 from fecfiler.s3 import S3_SESSION
 from fecfiler.celery import CeleryStorageType
-import logging
+import structlog
 
-logger = logging.getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def store_file(file_content, file_name, force_write_to_disk=False):

--- a/django-backend/scripts/json_schema_to_django_model.py
+++ b/django-backend/scripts/json_schema_to_django_model.py
@@ -12,8 +12,11 @@ standard and are specific to the FEC data.
 """
 import json
 import argparse
-import logging
 import os
+
+import structlog
+
+logger = structlog.get_logger(__name__)
 
 
 def determine_model_name(model_id=None, filename=None):
@@ -28,7 +31,7 @@ def determine_model_name(model_id=None, filename=None):
         try:
             model_name = model_id.split("/")[-1].replace(".json", "")
         except Exception as e:
-            logging.exception("Unhandled exception {}".format(e))
+            logger.exception("Unhandled exception {}".format(e))
 
     if not model_name and filename:
         filename = filename.strip(os.sep)

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,4 +26,5 @@ static3==0.7.0
 django-otp==1.1.4
 git+https://github.com/fecgov/mozilla-django-oidc.git@main#egg=mozilla_django_oidc
 zeep==4.2.1
-
+python-json-logger==2.0.7
+django-structlog[celery]==7.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ git+https://github.com/fecgov/mozilla-django-oidc.git@main#egg=mozilla_django_oi
 zeep==4.2.1
 python-json-logger==2.0.7
 django-structlog[celery]==7.1.0
+rich==13.7.0


### PR DESCRIPTION
## TODO
- [ ] Check on logging preferences for end-to-end tests
- [ ] Check wtih devs on logging output
- [ ] Review logs to look for opportunities for better data, clean up old-style string formatting to make key/value additions easier
- [ ] Look into exception handler
```python
# TODO: I think this is swallowing exceptions
REST_FRAMEWORK["EXCEPTION_HANDLER"] = "fecfiler.utils.custom_exception_handler"  # noqa
```
- [x] New fields

## Summary

- Issue api#651
  
Add structlog for json logging in prod

## How to test

- Run locally to see new API logs, go to http://localhost:8080/celery-test/ to see celery logs
- To test json, make the below changes, restart celery and go to http://localhost:8080/celery-test/. Check out API and celery logs

**django-backend/fecfiler/celery.py**
```python
def receiver_setup_logging(loglevel, logfile, format, colorize, **kwargs):
...
+    # logging.config.dictConfig(settings.get_env_logging_config(env.space))
+    logging.config.dictConfig(settings.get_env_logging_config(prod=True))
```
**django-backend/fecfiler/settings/base.py**
```python
-# LOGGING = get_env_logging_config()
+LOGGING = get_env_logging_config(prod=True)
```
**django-backend/fecfiler/settings/local.py**
```python
 structlog.configure(  # noqa
-  #  processors=get_env_logging_processors(), # noqa
+    processors=get_env_logging_processors(prod=True), # noqa
```