### PR TITLE
Update psycopg2-binary patch version to 2.9.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ invoke==1.7.3
 itypes==1.2.0
 MarkupSafe==2.1.1
 openapi-codec==1.3.2
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.6
 pytz==2022.6
 retry==0.9.2
 static3==0.7.0


### PR DESCRIPTION
## Summary

No ticket -  devops task
  
After pulling down the latest fecfile-api develop branch on my Mac M1, my local API couldn't connect to the postgres database. It would hang on `Testing connection...` and I eventually got the error `psycopg2.OperationalError: SCRAM authentication requires libpq version 10 or above`

After looking at [this issue](https://github.com/psycopg/psycopg2/issues/1360), I tried updating the psycopg2-binary to 2.9.6, which addressed the issue

[Per https://github.com/psycopg/psycopg2/issues/1360#issuecomment-1494156272](https://github.com/psycopg/psycopg2/issues/1360#issuecomment-1493293761)
> Will be fixed in 2.9.6.

## How to test

Rebuild docker images to get latest requirements file