### PR TITLE
feature/592 local add test user in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,4 @@ RUN useradd nxgu --no-create-home --home /opt/nxg_fec && chown -R nxgu:nxgu /opt
 USER nxgu
 
 EXPOSE 8080
-ENTRYPOINT ["/bin/sh", "-c", "python wait_for_db.py && python manage.py migrate && gunicorn --bind 0.0.0.0:8080 fecfiler.wsgi -w 10 --reload"]
+ENTRYPOINT ["/bin/sh", "-c", "python wait_for_db.py && python manage.py migrate && python manage.py loaddata fixtures/e2e-test-data.json && gunicorn --bind 0.0.0.0:8080 fecfiler.wsgi -w 10 --reload"]


### PR DESCRIPTION
Currently, running `docker compose up` on fecfile-web-api locally will cause it to come up without any test users or committees since 592 removed the loading of the db_backup file.

Running the e2e fixtures will fix that and give us test@fec.gov/C00601211 back.

In the meantime, this workaround to set env vars will also give it back (but generating .fec files won't work):

add these to your .env and restart the api as a workaround
```
DB_DOCKERFILE="Dockerfile-e2e"
WORKER_DOCKERFILE="Worker_Dockerfile-e2e"
API_DOCKERFILE="Dockerfile-e2e"
```