### PR TITLE
Give test committee a uuid

### DIFF
--- a/django-backend/fixtures/e2e-test-data.json
+++ b/django-backend/fixtures/e2e-test-data.json
@@ -1,72 +1,73 @@
 [
-{
-    "model": "authentication.account",
-    "pk": 165,
-    "fields": {
-        "password": "pbkdf2_sha256$260000$8lcKqWHCEOwOMqtzTV6oDr$/fvcNuEmdyOaEpKjISOJuwngn5enhl3uSaEDI7N+RNk=",
-        "is_superuser": false,
-        "email": "test@test.com",
-        "username": "C00601211test@test.com",
-        "cmtee_id": "C00601211",
-        "contact": "2022519761",
-        "first_name": "Test",
-        "last_name": "Testson",
-        "role": "C_ADMIN",
-        "tagline": "",
-        "delete_ind": "N",
-        "created_at": "2020-09-28T15:22:56.477Z",
-        "updated_at": "2020-09-28T15:22:56.477Z",
-        "last_login": "2022-05-02T13:44:07.324Z",
-        "is_staff": false,
-        "is_active": true,
-        "date_joined": "2020-09-28T15:22:56.477Z",
-        "login_code_counter": "2",
-        "register_token": "string",
-        "personal_key": "idunnohowaboutyou",
-        "status": "Registered",
-        "code_generated_counter": "0",
-        "secret_key": "pbkdf2_sha256$150000$SseiMBChJMqH$CXjJXopTZOUXZ5DpH81+UI7wrP7URdyG2siDPYn2sAY=",
-        "groups": [],
-        "user_permissions": []
+    {
+        "model": "authentication.account",
+        "pk": 165,
+        "fields": {
+            "password": "pbkdf2_sha256$260000$8lcKqWHCEOwOMqtzTV6oDr$/fvcNuEmdyOaEpKjISOJuwngn5enhl3uSaEDI7N+RNk=",
+            "is_superuser": false,
+            "email": "test@test.com",
+            "username": "C00601211test@test.com",
+            "cmtee_id": "C00601211",
+            "contact": "2022519761",
+            "first_name": "Test",
+            "last_name": "Testson",
+            "role": "C_ADMIN",
+            "tagline": "",
+            "delete_ind": "N",
+            "created_at": "2020-09-28T15:22:56.477Z",
+            "updated_at": "2020-09-28T15:22:56.477Z",
+            "last_login": "2022-05-02T13:44:07.324Z",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2020-09-28T15:22:56.477Z",
+            "login_code_counter": "2",
+            "register_token": "string",
+            "personal_key": "idunnohowaboutyou",
+            "status": "Registered",
+            "code_generated_counter": "0",
+            "secret_key": "pbkdf2_sha256$150000$SseiMBChJMqH$CXjJXopTZOUXZ5DpH81+UI7wrP7URdyG2siDPYn2sAY=",
+            "groups": [],
+            "user_permissions": []
+        }
+    },
+    {
+        "model": "authentication.account",
+        "pk": 175,
+        "fields": {
+            "password": "pbkdf2_sha256$150000$x0245whwObY6$j3O4N6GCXOyVUdhd72ioy5ZGT8hbwrtB6pqWnSxHyFc=",
+            "is_superuser": false,
+            "email": "test@fec.gov",
+            "username": "C00601211test@fec.gov",
+            "cmtee_id": "C00601211",
+            "contact": "2022519761",
+            "first_name": "first_name_175",
+            "last_name": "last_name_175",
+            "role": "C_ADMIN",
+            "tagline": "",
+            "delete_ind": "N",
+            "created_at": "2020-09-28T15:22:56.477Z",
+            "updated_at": "2020-09-28T15:22:56.477Z",
+            "last_login": "2022-05-02T13:44:07.324Z",
+            "is_staff": false,
+            "is_active": true,
+            "date_joined": "2020-09-28T15:22:56.477Z",
+            "login_code_counter": "2",
+            "register_token": "",
+            "personal_key": "",
+            "status": "Registered",
+            "code_generated_counter": "1",
+            "secret_key": "pbkdf2_sha256$150000$jcZaVwLbiTm0$MOd8ZzHWSqGGlGBBDA0BfN9VXe3uhZ5iiMee9JpXwSM=",
+            "groups": [],
+            "user_permissions": []
+        }
+    },
+    {
+        "model": "committee_accounts.CommitteeAccount",
+        "pk": "c94c5d1a-9e73-464d-ad72-b73b5d8667a9",
+        "fields": {
+            "committee_id": "C00601211",
+            "created": "2022-02-09T00:00:00.000Z",
+            "updated": "2022-02-09T00:00:00.000Z"
+        }
     }
-},
-{
-    "model": "authentication.account",
-    "pk": 175,
-    "fields": {
-        "password": "pbkdf2_sha256$150000$x0245whwObY6$j3O4N6GCXOyVUdhd72ioy5ZGT8hbwrtB6pqWnSxHyFc=",
-        "is_superuser": false,
-        "email": "test@fec.gov",
-        "username": "C00601211test@fec.gov",
-        "cmtee_id": "C00601211",
-        "contact": "2022519761",
-        "first_name": "first_name_175",
-        "last_name": "last_name_175",
-        "role": "C_ADMIN",
-        "tagline": "",
-        "delete_ind": "N",
-        "created_at": "2020-09-28T15:22:56.477Z",
-        "updated_at": "2020-09-28T15:22:56.477Z",
-        "last_login": "2022-05-02T13:44:07.324Z",
-        "is_staff": false,
-        "is_active": true,
-        "date_joined": "2020-09-28T15:22:56.477Z",
-        "login_code_counter": "2",
-        "register_token": "",
-        "personal_key": "",
-        "status": "Registered",
-        "code_generated_counter": "1",
-        "secret_key": "pbkdf2_sha256$150000$jcZaVwLbiTm0$MOd8ZzHWSqGGlGBBDA0BfN9VXe3uhZ5iiMee9JpXwSM=",
-        "groups": [],
-        "user_permissions": []
-    }
-},
-{
-    "model": "committee_accounts.CommitteeAccount",
-    "fields": {
-        "committee_id": "C00601211",
-        "created": "2022-02-09T00:00:00.000Z",
-        "updated": "2022-02-09T00:00:00.000Z"
-    }
-}
 ]


### PR DESCRIPTION
If you try to start docker up again locally, the e2e-test-data.json fails to load because the C00601211 committee colides with itself.  Giving it an id changes it to just write to the same record.

NOTE:  You certainly have a different uuid for that committee locally.  If you need to keep your local data for some reason, you could change the pk in the fixture to match yours until you're ready for the clean slate.