### PR TITLE
declare alternative login method rather than boolean

### DIFF
--- a/django-backend/fecfiler/authentication/views.py
+++ b/django-backend/fecfiler/authentication/views.py
@@ -14,7 +14,7 @@ from fecfiler.settings import (
     OIDC_RP_CLIENT_ID,
     LOGOUT_REDIRECT_URL,
     OIDC_OP_LOGOUT_ENDPOINT,
-    USERNAME_PASSWORD_LOGIN_AVAILABLE,
+    ALTERNATIVE_LOGIN,
 )
 
 from rest_framework.response import Response
@@ -31,6 +31,11 @@ from django.http import JsonResponse
 import logging
 
 logger = logging.getLogger(__name__)
+
+"""
+Option for :py:const:`fecfiler.settings.base.ALTERNATIVE_LOGIN`. See :py:meth:`fecfiler.authentication.views.authenticate_login`
+"""
+USERNAME_PASSWORD = "USERNAME_PASSWORD"
 
 
 class AccountViewSet(GenericViewSet, ListModelMixin):
@@ -159,10 +164,11 @@ def logout_redirect(request):
 @permission_classes([])
 @require_http_methods(["GET", "POST"])
 def authenticate_login(request):
+    endpoint_is_available = ALTERNATIVE_LOGIN == USERNAME_PASSWORD
     if request.method == "GET":
-        return JsonResponse({"endpoint_available": USERNAME_PASSWORD_LOGIN_AVAILABLE})
+        return JsonResponse({"endpoint_available": endpoint_is_available})
 
-    if not USERNAME_PASSWORD_LOGIN_AVAILABLE:
+    if not endpoint_is_available:
         return JsonResponse(status=405, safe=False)
 
     username = request.data.get("username", None)

--- a/django-backend/fecfiler/authentication/views.py
+++ b/django-backend/fecfiler/authentication/views.py
@@ -33,7 +33,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 """
-Option for :py:const:`fecfiler.settings.base.ALTERNATIVE_LOGIN`. See :py:meth:`fecfiler.authentication.views.authenticate_login`
+Option for :py:const:`fecfiler.settings.base.ALTERNATIVE_LOGIN`.
+See :py:meth:`fecfiler.authentication.views.authenticate_login`
 """
 USERNAME_PASSWORD = "USERNAME_PASSWORD"
 

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -25,7 +25,8 @@ CSRF_TRUSTED_ORIGINS = [
 ]
 
 """
-Enables alternative log in method. See :py:const:`fecfiler.authentication.views.USERNAME_PASSWORD`
+Enables alternative log in method.
+See :py:const:`fecfiler.authentication.views.USERNAME_PASSWORD`
 and :py:meth:`fecfiler.authentication.views.authenticate_login`
 """
 ALTERNATIVE_LOGIN = env.get_credential("ALTERNATIVE_LOGIN")

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -24,10 +24,11 @@ CSRF_TRUSTED_ORIGINS = [
     env.get_credential("CSRF_TRUSTED_ORIGINS", "http://localhost:4200")
 ]
 
-# Determines whether or not a user can login with a username/password combo
-USERNAME_PASSWORD_LOGIN_AVAILABLE = env.get_credential(
-    "USERNAME_PASSWORD_LOGIN_AVAILABLE", False
-)
+"""
+Enables alternative log in method. See :py:const:`fecfiler.authentication.views.USERNAME_PASSWORD`
+and :py:meth:`fecfiler.authentication.views.authenticate_login`
+"""
+ALTERNATIVE_LOGIN = env.get_credential("ALTERNATIVE_LOGIN")
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = env.get_credential("DJANGO_SECRET_KEY", get_random_string(50))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
     links:
       - redis
     environment:
-      USERNAME_PASSWORD_LOGIN_AVAILABLE: True
+      ALTERNATIVE_LOGIN: USERNAME_PASSWORD
       REDIS_URL: redis://redis:6379
       DATABASE_URL:
       FECFILE_TEST_DB_NAME:

--- a/manifests/manifest-dev-api.yml
+++ b/manifests/manifest-dev-api.yml
@@ -15,7 +15,6 @@ applications:
       - fecfile-api-redis
       - fecfile-api-creds-dev
     env:
-      USERNAME_PASSWORD_LOGIN_AVAILABLE: False
       DISABLE_COLLECTSTATIC: 1
       DJANGO_SETTINGS_MODULE: fecfiler.settings.production
       CORS_ALLOWED_ORIGINS: https://fecfile-web-app-dev.app.cloud.gov

--- a/manifests/manifest-prod-api.yml
+++ b/manifests/manifest-prod-api.yml
@@ -15,7 +15,6 @@ applications:
       - fecfile-api-redis
       - fecfile-api-creds-prod
     env:
-      USERNAME_PASSWORD_LOGIN_AVAILABLE: False
       CORS_ALLOWED_ORIGINS: https://fecfile-web-app-prod.app.cloud.gov
       CSRF_TRUSTED_ORIGINS: https://fecfile-web-app-prod.app.cloud.gov
       DISABLE_COLLECTSTATIC: 1

--- a/manifests/manifest-stage-api.yml
+++ b/manifests/manifest-stage-api.yml
@@ -15,7 +15,6 @@ applications:
       - fecfile-api-redis
       - fecfile-api-creds-stage
     env:
-      USERNAME_PASSWORD_LOGIN_AVAILABLE: False
       CORS_ALLOWED_ORIGINS: https://fecfile-web-app-stage.app.cloud.gov
       CSRF_TRUSTED_ORIGINS: https://fecfile-web-app-stage.app.cloud.gov
       DISABLE_COLLECTSTATIC: 1


### PR DESCRIPTION
It seems like there were two options.  One was to try to parse whatever value was in `USERNAME_PASSWORD_LOGIN_AVAILABLE` into a boolean. 
```
USERNAME_PASSWORD_LOGIN_AVAILABLE = env.get_credential("USERNAME_PASSWORD_LOGIN_AVAILABLE", 'False').lower() in ('true', '1', 't')
``` 
That seemed dirty to me.  My alternative was to make the setting a declaration of what it was enabling.