### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ export DATABASE_URL="postgres://postgres:postgres@db/postgres"
 export FECFILE_TEST_DB_NAME="postgres"
 export DJANGO_SECRET_KEY="If_using_test_db_use_secret_key_in_cloud.gov"
 export FEC_API="https://api.open.fec.gov/v1/"
-# Note - this API key has a very low rate limit - reach out to a team member or get a key at https://api.open.fec.gov/developers/
+# Note - this API key has a very low rate limit -
+# For a better key, reach out to a team member or get one at https://api.open.fec.gov/developers/
 export FEC_API_KEY="DEMO_KEY"
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ export FEC_API="https://api.open.fec.gov/v1/"
 # Note - this API key has a very low rate limit -
 # For a better key, reach out to a team member or get one at https://api.open.fec.gov/developers/
 export FEC_API_KEY="DEMO_KEY"
+# Test EFO Services (for test filings):
+export FEC_FILING_API="EFO_get_this_from_team_member"
+export FEC_FILING_API_KEY="EFO_get_this_from_team_member"
 ```
 
 ### Shut down the containers

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ export DATABASE_URL="postgres://postgres:postgres@db/postgres"
 export FECFILE_TEST_DB_NAME="postgres"
 export DJANGO_SECRET_KEY="If_using_test_db_use_secret_key_in_cloud.gov"
 export FEC_API="https://api.open.fec.gov/v1/"
+# Note - this API key has a very low rate limit - reach out to a team member or get a key at https://api.open.fec.gov/developers/
 export FEC_API_KEY="DEMO_KEY"
 ```
 


### PR DESCRIPTION
Better API key info - `DEMO_KEY` has a very low limit

Env vars for test EFO filings
