### PR TITLE
feature/643 remove django page

### DIFF
--- a/django-backend/fecfiler/urls.py
+++ b/django-backend/fecfiler/urls.py
@@ -16,7 +16,6 @@ def test_celery(request):
 
 
 urlpatterns = [
-    re_path(r"^api-auth/", include("rest_framework.urls", namespace="rest_framework")),
     re_path(
         r"^api/schema/", SpectacularAPIView.as_view(api_version="v1"), name="schema"
     ),


### PR DESCRIPTION
This change also removes the "Log in" link from the celery-test page

https://app.zenhub.com/workspaces/fecfile-online-619e578e68408b001c831251/issues/gh/fecgov/fecfile-web-api/643