### PR TITLE
Test conn_max_age

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,8 @@ workflows:
             - dependency-check
           filters:
             branches:
-              only: /develop|release\/sprint-\d+|main/
+              # only: /develop|release\/sprint-\d+|main/
+              only: mod/release-sprint-38-conn-max-age
       - docs-build:
           requires:
             - test

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -121,7 +121,10 @@ CORS_ALLOW_CREDENTIALS = True
 DATABASES = {
     # Be sure to set the DATABASE_URL environment variable on your local
     # development machine so that the local database can be connected to.
-    "default": dj_database_url.config()
+    "default": dj_database_url.config(
+        conn_max_age=600,
+        conn_health_checks=True,
+    )
 }
 
 # Override default test name

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cfenv==0.5.3
 coreapi==2.3.3
 coreschema==0.0.4
 decorator==5.1.1
-dj-database-url==1.0.0
+dj-database-url==1.3.0
 dj-static==0.0.6
 Django==4.2.7  # when updating this, also update requirements/tox versions in fecgov/mozilla_django_oidc
 django-cors-headers==3.13.0

--- a/tasks.py
+++ b/tasks.py
@@ -49,7 +49,8 @@ def _detect_space(repo, branch=None):
 
 DEPLOY_RULES = (
     ("prod", lambda _, branch: branch == "main"),
-    ("stage", lambda _, branch: branch.startswith("release")),
+    # ("stage", lambda _, branch: branch.startswith("release")),
+    ("stage", lambda _, branch: branch == "mod/release-sprint-38-conn-max-age"),
     ("dev", lambda _, branch: branch == "develop"),
 )
 


### PR DESCRIPTION
## Summary

Test `conn_max_age` setting for database connection pooling

>conn_max_age sets the [CONN_MAX_AGE setting](https://docs.djangoproject.com/en/stable/ref/settings/#conn-max-age), which tells Django to persist database connections between requests, up to the given lifetime in seconds. If you do not provide a value, it will follow Django’s default of 0. Setting it is recommended for performance.

https://pypi.org/project/dj-database-url/#:~:text=conn_max_age%20sets%20the%20CONN_MAX_AGE%20setting,it%20is%20recommended%20for%20performance. 


## How to test

(Include any information that may be helpful to the reviewer(s). This might include links to sample pages to test or any local environmental setup that is unusual such as environment variable (never credentials), API version to point to, etc)

- 
