### PR TITLE
patch - Ensure transactions are being deleted when hard deleting reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
       - run:
           name: Run tests
           # Use built-in Django test module
-          command: coverage run --source='.' --rcfile=.coveragerc manage.py test --keepdb
+          command: coverage run --source='.' --rcfile=.coveragerc manage.py test
           working_directory: ~/project/django-backend/
 
       - run:

--- a/django-backend/fecfiler/reports/managers.py
+++ b/django-backend/fecfiler/reports/managers.py
@@ -20,8 +20,6 @@ class ReportManager(SoftDeleteManager):
         queryset = (
             super()
             .get_queryset()
-            .distinct()  # Remove duplicates caused by multiple transaction
-                         # foreign key links
             .annotate(
                 report_type=Case(
                     When(form_3x__isnull=False, then=ReportType.F3X.value),

--- a/django-backend/fecfiler/reports/views.py
+++ b/django-backend/fecfiler/reports/views.py
@@ -126,9 +126,10 @@ class ReportViewSet(CommitteeOwnedViewMixin, ModelViewSet):
 
         reports = Report.objects.filter(committee_account__committee_id=committee_id)
         report_count = reports.count()
-        transaction_count = Transaction.objects.filter(
+        transactions = Transaction.objects.filter(
             committee_account__committee_id=committee_id
-        ).count()
+        )
+        transaction_count = transactions.count()
         memo_count = MemoText.objects.filter(
             report__committee_account__committee_id=committee_id
         ).count()
@@ -149,6 +150,7 @@ class ReportViewSet(CommitteeOwnedViewMixin, ModelViewSet):
         logger.warn(f"WebPrint Submissions: {web_print_submission_count}")
 
         reports.hard_delete()
+        transactions.hard_delete()
         return Response(f"Deleted {report_count} Reports")
 
     def create(self, request):

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -124,11 +124,6 @@ DATABASES = {
     "default": dj_database_url.config()
 }
 
-# Override default test name
-DATABASES["default"]["TEST"] = {
-    "NAME": os.environ.get("FECFILE_TEST_DB_NAME", "postgres")
-}
-
 # Connection string for connecting directly
 DATABASE_URL = os.environ.get("DATABASE_URL")
 

--- a/django-backend/fecfiler/transactions/managers.py
+++ b/django-backend/fecfiler/transactions/managers.py
@@ -206,7 +206,9 @@ class TransactionManager(SoftDeleteManager):
             When(
                 schedule_c__isnull=False,
                 then=Concat(
-                    F("transaction_id"), F("schedule_c__report_coverage_through_date")
+                    F("transaction_id"),
+                    F("schedule_c__report_coverage_through_date"),
+                    Value("LOAN")
                 ),
             ),
             default=None,


### PR DESCRIPTION
This is a technical debt patch that corrects the following issues:

1. Ensuring the transactions delete when clearing reports out for a committee by using the hard-delete endpoint
2. Update loan_key to include "LOAN" suffix for schedule C loan transactions to fix window function sort order when calculating loan_payment_to_date
3. Removing distinct() call from Report manager. This is OBE with the subquery clause fix for transactions.