### PR TITLE
806 - Unable to pull forward loan transactions that have a memo text

### DIFF
--- a/django-backend/fecfiler/transactions/managers.py
+++ b/django-backend/fecfiler/transactions/managers.py
@@ -216,16 +216,14 @@ class TransactionManager(SoftDeleteManager):
         )
 
     def LOAN_PAYMENT_CLAUSE(self):  # noqa: N802
-        return Coalesce(
-            Case(
-                When(
-                    schedule_c__isnull=False,
-                    then=Window(
-                        expression=Sum("effective_amount"), **self.loan_payment_window
-                    ),
-                )
-            ),
-            Value(Decimal(0)),
+        return Case(
+            When(
+                schedule_c__isnull=False,
+                then=Coalesce(Window(
+                    expression=Sum("effective_amount"),
+                    **self.loan_payment_window
+                ), Value(Decimal(0)))
+            )
         )
 
     def INCURRED_PRIOR_CLAUSE(self):  # noqa: N802

--- a/django-backend/fecfiler/transactions/managers.py
+++ b/django-backend/fecfiler/transactions/managers.py
@@ -314,7 +314,10 @@ class TransactionManager(SoftDeleteManager):
                 payment_prior=self.PAYMENT_PRIOR_CLAUSE(),
                 payment_amount=self.PAYMENT_AMOUNT_CLAUSE(),
                 loan_key=self.LOAN_KEY_CLAUSE(),
-                loan_payment_to_date=self.LOAN_PAYMENT_CLAUSE(),
+                loan_payment_to_date=Coalesce(
+                    self.LOAN_PAYMENT_CLAUSE(),
+                    Value(Decimal(0))
+                ),
                 _itemized=self.ITEMIZATION_CLAUSE(),
                 form_type=self.FORM_TYPE_CLAUSE,
                 name=self.DISPLAY_NAME_CLAUSE,

--- a/django-backend/fecfiler/transactions/schedule_c/utils.py
+++ b/django-backend/fecfiler/transactions/schedule_c/utils.py
@@ -85,6 +85,7 @@ def carry_forward_loan(loan, report):
                     "contact_3",
                     "schedule_c",
                     "loan",
+                    "memo_text",
                 ],
             )
         ),

--- a/django-backend/fecfiler/transactions/schedule_c2/utils.py
+++ b/django-backend/fecfiler/transactions/schedule_c2/utils.py
@@ -48,9 +48,6 @@ def carry_forward_guarantor(report, new_loan, guarantor):
             "contact_2_id": guarantor.contact_2_id,
             "contact_3_id": guarantor.contact_3_id,
             "schedule_c2": save_copy(guarantor.schedule_c2),
-            "memo_text": (
-                save_copy(guarantor.memo_text) if guarantor.memo_text else None
-            ),
             "committee_account_id": new_loan.committee_account_id,
             "report_id": report.id,
             "parent_transaction_id": new_loan.id,


### PR DESCRIPTION
Bug fixes caught by e2e tests:

1. Exception thrown when pulling forward a loan with a memo text.
2. Null value being shown in front end (and unable to save an edited loan) when no payments