### PR TITLE
781 - Increase api (`fecfile-web-api`) memory to 2GB

### DIFF
--- a/manifests/manifest-dev-api.yml
+++ b/manifests/manifest-dev-api.yml
@@ -8,7 +8,7 @@ applications:
     buildpacks:
       - python_buildpack
     command: bin/run-api.sh
-    memory: 1G
+    memory: 2G
     services:
       - fecfile-api-rds
       - fecfile-api-s3

--- a/manifests/manifest-prod-api.yml
+++ b/manifests/manifest-prod-api.yml
@@ -8,7 +8,7 @@ applications:
     buildpacks:
       - python_buildpack
     command: bin/run-api.sh
-    memory: 1G
+    memory: 2G
     services:
       - fecfile-api-rds
       - fecfile-api-s3

--- a/manifests/manifest-stage-api.yml
+++ b/manifests/manifest-stage-api.yml
@@ -8,7 +8,7 @@ applications:
     buildpacks:
       - python_buildpack
     command: bin/run-api.sh
-    memory: 1G
+    memory: 2G
     services:
       - fecfile-api-rds
       - fecfile-api-s3


### PR DESCRIPTION
## Summary

- Issue api#781
  
Increase api memory to 2GB. Memory allocation stats: https://github.com/fecgov/fecfile-web-api/issues/781#issuecomment-2039901244

Org memory tracking spreadsheet: https://docs.google.com/spreadsheets/d/1EsY3zOFv2mv9-f-sf64xbPI8dUGwEawQN2l68aHtO5w/edit#gid=0

## How to test

Manual deploy, then
`cf app fecfile-web-api`
