### PR TITLE
hotfix/386-2: Move report_status to serializer so it can be used by can_delete to check if status is In progress

### DIFF
--- a/django-backend/fecfiler/reports/views.py
+++ b/django-backend/fecfiler/reports/views.py
@@ -5,11 +5,10 @@ from rest_framework.viewsets import GenericViewSet, ModelViewSet
 from fecfiler.committee_accounts.views import CommitteeOwnedViewMixin
 from .models import Report
 from fecfiler.transactions.models import Transaction
-from fecfiler.web_services.models import FECSubmissionState, FECStatus
 from fecfiler.memo_text.models import MemoText
 from fecfiler.web_services.models import DotFEC, UploadSubmission, WebPrintSubmission
 from .serializers import ReportSerializer
-from django.db.models import Case, Value, When, Q, CharField
+from django.db.models import Case, Value, When
 import structlog
 
 
@@ -44,23 +43,6 @@ report_code_label_mapping = Case(
 )
 
 
-def get_status_mapping():
-    """returns Django Case that determines report status based on upload submission"""
-    upload_exists = Q(upload_submission__isnull=False)
-    success = Q(upload_submission__fec_status=FECStatus.ACCEPTED)
-    failed = Q(upload_submission__fecfile_task_state=FECSubmissionState.FAILED) | Q(
-        upload_submission__fec_status=FECStatus.REJECTED
-    )
-
-    return Case(
-        When(success, then=Value("Submission success")),
-        When(failed, then=Value("Submission failure")),
-        When(upload_exists, then=Value("Submission pending")),
-        default=Value("In progress"),
-        output_field=CharField(),
-    )
-
-
 class ReportViewSet(CommitteeOwnedViewMixin, ModelViewSet):
     """
     This viewset automatically provides `list`, `create`, `retrieve`,
@@ -71,11 +53,9 @@ class ReportViewSet(CommitteeOwnedViewMixin, ModelViewSet):
     in CommitteeOwnedViewMixin's implementation of get_queryset()
     """
 
-    queryset = (
-        Report.objects.annotate(report_code_label=report_code_label_mapping)
-        .annotate(report_status=get_status_mapping())
-        .all()
-    )
+    queryset = Report.objects.annotate(
+        report_code_label=report_code_label_mapping
+    ).all()
 
     serializer_class = ReportSerializer
     filter_backends = [filters.OrderingFilter]


### PR DESCRIPTION
Issue was that I had originally been doing the status check on the front end and then was calling an end point to check if it could be deleted if the status was In progress. However we refactored the can_delete on the api to be part of the serializer, but it was never accounting for the status as it was happening on the front end. But it no longer made sense to have it on the front end since we're just checking against a single can_delete variable which should be accounting for status.

However, to update the can_delete function in the serializer, I needed to move the get_status_mapping() annotation from the view into the serializer, so that the report status would be available to check for the can_delete function.