### PR TITLE
hotfix/386-3 - Add str mixin to enums to allow string comparison

### DIFF
--- a/django-backend/fecfiler/web_services/models.py
+++ b/django-backend/fecfiler/web_services/models.py
@@ -27,7 +27,7 @@ class DotFEC(ReportMixin):
         db_table = "dot_fecs"
 
 
-class FECSubmissionState(Enum):
+class FECSubmissionState(str, Enum):
     """States of submission to FEC
     Can be used for Webload and WebPrint"""
 
@@ -41,7 +41,7 @@ class FECSubmissionState(Enum):
         return str(self.value)
 
 
-class FECStatus(Enum):
+class FECStatus(str, Enum):
     ACCEPTED = "ACCEPTED"  # Webload
     COMPLETED = "COMPLETED"  # WebPrint
     PROCESSING = "PROCESSING"


### PR DESCRIPTION
Made FECSubmissionState and FECStatus enums also use the str mixin so == comparison works against a string value.
Apparently in Python 3.11 (we're on 3.10) there's a new StrEnum we could also use to accomplish the same thing.