### PR TITLE
Fix type incompatibility in locust run script

### DIFF
--- a/locust-testing/locust_run.py
+++ b/locust-testing/locust_run.py
@@ -17,13 +17,13 @@ SESSION_ID = os.environ.get("OIDC_SESSION_ID")
 TIMEOUT = 30  # seconds
 
 # item counts
-WANTED_REPORTS = os.environ.get("LOCUST_WANTED_REPORTS", 10)
-WANTED_CONTACTS = os.environ.get("LOCUST_WANTED_CONTACTS", 100)
-WANTED_TRANSACTIONS = os.environ.get("LOCUST_WANTED_TRANSACTIONS", 500)
-SINGLE_TO_TRIPLE_RATIO = os.environ.get(
+WANTED_REPORTS = int(os.environ.get("LOCUST_WANTED_REPORTS", 10))
+WANTED_CONTACTS = int(os.environ.get("LOCUST_WANTED_CONTACTS", 100))
+WANTED_TRANSACTIONS = int(os.environ.get("LOCUST_WANTED_TRANSACTIONS", 500))
+SINGLE_TO_TRIPLE_RATIO = float(os.environ.get(
     "LOCUST_TRANSACTIONS_SINGLE_TO_TRIPLE_RATIO",
     9 / 10
-)
+))
 
 SCHEDULES = ["A"]  # Further schedules to be implemented in the future
 


### PR DESCRIPTION
This patch fixes an error when setting the custom parameters for the locust testing:

LOCUST_WANTED_REPORTS
LOCUST_WANTED_CONTACTS
LOCUST_WANTED_TRANSACTIONS
SINGLE_TO_TRIPLE_RATIO

The variables needed to be cast into and int or float for comparison operations would work properly with them.