### PR TITLE
patch report status

### DIFF
--- a/django-backend/fecfiler/reports/form_3x/tests/test_serializers.py
+++ b/django-backend/fecfiler/reports/form_3x/tests/test_serializers.py
@@ -116,7 +116,7 @@ class F3XSerializerTestCase(TestCase):
         self.assertEquals(representation["report_status"], "Submission failure")
 
         # .fec was submitted and efo came back with a 'rejected'
-        f3x_report.upload_submission.fecfile_task_state = None
+        f3x_report.upload_submission.fecfile_task_state = FECSubmissionState.SUBMITTING
         f3x_report.upload_submission.fec_status = FECStatus.REJECTED
         f3x_report.upload_submission.save()
         # retrieve from manager to populate annotations

--- a/django-backend/fecfiler/reports/managers.py
+++ b/django-backend/fecfiler/reports/managers.py
@@ -27,7 +27,8 @@ def get_status_mapping():
         When(failed, then=Value("Submission failure")),
         # the report has been sent to efo, we are waiting on a response
         When(upload_exists, then=Value("Submission pending")),
-        # the report is in progress because there is no upload_submission associated with it
+        # the report is in progress because there is no
+        # upload_submission associated with it
         default=Value("In progress"),
         output_field=CharField(),
     )

--- a/django-backend/fecfiler/reports/managers.py
+++ b/django-backend/fecfiler/reports/managers.py
@@ -1,8 +1,36 @@
-from django.db.models import Case, When, Value, OuterRef, Exists, Manager
+from django.db.models import Case, When, Value, OuterRef, Exists, Manager, Q, CharField
 from enum import Enum
 
 """Manager to deterimine fields that are used the same way across reports,
 but are called different names"""
+
+
+def get_status_mapping():
+    """returns Django Case that determines report status based on upload submission"""
+    from fecfiler.web_services.models import FECSubmissionState, FECStatus
+
+    # there is an upload record, meaning the user submitted the report, but it could
+    # be at any stage in the process
+    upload_exists = Q(upload_submission__isnull=False)
+    # if the `fec_status` is ACCEPTED, efo has accepted the submission
+    success = Q(upload_submission__fec_status=FECStatus.ACCEPTED)
+    # if the `fecfile_task_state` is FAILED, there was an error in one of our tasks
+    # if the `fec_status` is REJECTED, efo deemed the submission to not be successful
+    failed = Q(upload_submission__fecfile_task_state=FECSubmissionState.FAILED) | Q(
+        upload_submission__fec_status=FECStatus.REJECTED
+    )
+
+    return Case(
+        # the report was submitted and efo returned a "success"
+        When(success, then=Value("Submission success")),
+        # the submission failed either on our side or efo's side
+        When(failed, then=Value("Submission failure")),
+        # the report has been sent to efo, we are waiting on a response
+        When(upload_exists, then=Value("Submission pending")),
+        # the report is in progress because there is no upload_submission associated with it
+        default=Value("In progress"),
+        output_field=CharField(),
+    )
 
 
 class ReportManager(Manager):
@@ -27,6 +55,8 @@ class ReportManager(Manager):
                     When(form_1m__isnull=False, then=ReportType.F1M.value),
                 ),
                 is_first=~Exists(older_f3x),
+                # report status must be in queryset because it is sorted on
+                report_status=get_status_mapping(),
             )
         )
         return queryset

--- a/django-backend/fecfiler/reports/serializers.py
+++ b/django-backend/fecfiler/reports/serializers.py
@@ -19,7 +19,6 @@ from fecfiler.reports.form_1m.models import Form1M
 from fecfiler.reports.form_1m.utils import add_form_1m_contact_fields
 from django.db.models import OuterRef, Subquery, Exists, Q
 import structlog
-from fecfiler.web_services.models import FECSubmissionState, FECStatus
 
 logger = structlog.get_logger(__name__)
 

--- a/django-backend/fecfiler/reports/serializers.py
+++ b/django-backend/fecfiler/reports/serializers.py
@@ -137,7 +137,6 @@ class ReportSerializer(CommitteeOwnedSerializer, FecSchemaValidatorSerializerMix
             this_report = Report.objects.get(id=representation["id"])
             representation["is_first"] = this_report.is_first if this_report else True
 
-        representation["report_status"] = self.get_status_mapping(instance)
         representation["can_delete"] = self.can_delete(representation)
 
         return representation
@@ -176,19 +175,6 @@ class ReportSerializer(CommitteeOwnedSerializer, FecSchemaValidatorSerializerMix
                 ).exists()
             )
         )
-
-    def get_status_mapping(self, instance):
-        if instance.upload_submission is None:
-            return "In progress"
-        if instance.upload_submission.fec_status == FECStatus.ACCEPTED:
-            return "Submission success"
-        if (
-            instance.upload_submission.fec_status == FECSubmissionState.FAILED
-            or instance.upload_submission.fec_status == FECStatus.REJECTED
-        ):
-            return "Submission failure"
-
-        return "Submission pending"
 
     def validate(self, data):
         self._context = self.context.copy()


### PR DESCRIPTION
`report_status` needs to be in the queryset because it is sorted on
also
have to check `fecfile_task_state` for `FAILED` because we are checking the state of our fecfile task, not the submission on EFO which has its state tracked in `fec_status` which admittedly could be clearer if it was called `efo_status`