### PR TITLE
Log exceptions

### DIFF
--- a/django-backend/fecfiler/celery.py
+++ b/django-backend/fecfiler/celery.py
@@ -23,7 +23,7 @@ app = Celery("fecfiler")
 app.config_from_object("django.conf:settings", namespace="CELERY")
 
 # A step to initialize django-structlog
-app.steps['worker'].add(DjangoStructLogInitStep)
+app.steps["worker"].add(DjangoStructLogInitStep)
 
 env = cfenv.AppEnv()
 
@@ -34,12 +34,12 @@ def receiver_setup_logging(loglevel, logfile, format, colorize, **kwargs):
     Celery and environment-specific logging
     See https://django-structlog.readthedocs.io/en/latest/celery.html
     """
-    log_format = env.get_credential('LOG_FORMAT')
+    log_format = env.get_credential("LOG_FORMAT")
 
     logging.config.dictConfig(settings.get_logging_config(log_format))
 
     structlog.configure(
-        processors=settings.get_env_logging_processors(log_format),
+        processors=settings.get_logging_processors(),
         logger_factory=structlog.stdlib.LoggerFactory(),
         cache_logger_on_first_use=True,
     )

--- a/django-backend/fecfiler/utils.py
+++ b/django-backend/fecfiler/utils.py
@@ -11,13 +11,10 @@ def custom_exception_handler(exc, context):
     # Call REST framework's default exception handler first,
     # to get the standard error response.
 
-    # somebody please bring back my exceptions
-    # if exc:
-    #     raise exc
+    logger.exception(exc)
     response = exception_handler(exc, context)
 
     if response is None:
-        logger.error(f"Error: {exc}")
         return HttpResponseServerError()
 
     # Delete user cookies on forbidden http response.


### PR DESCRIPTION
`KEY_VALUE` output (what we use on our deployments):
>fecfile-api              | level='error' event=IndexError('list index out of range') logger='fecfiler.utils' ip='192.168.0.1' request_id='6620646d-1c85-4937-990a-a5e01c4ef4ac' user_id='2faed187-f4b5-46b4-a0d9-4a250ac792da' _record=<LogRecord: fecfiler.utils, 40, /opt/nxg_fec/fecfiler/utils.py, 14, "{'exc_info': True, 'event': IndexError('list index out of range'), 'ip': '192.168.0.1', 'request_id': '6620646d-1c85-4937-990a-a5e01c4ef4ac', 'user_id': '2faed187-f4b5-46b4-a0d9-4a250ac792da', 'logger': 'fecfiler.utils', 'level': 'error'}"> _from_structlog=True exception='Traceback (most recent call last):\n  File "/usr/local/lib/python3.10/site-packages/rest_framework/views.py", line 506, in dispatch\n    response = handler(request, *args, **kwargs)\n  File "/opt/nxg_fec/fecfiler/reports/views.py", line 150, in list\n    [1, 3][3]\nIndexError: list index out of range'

`LOCAL` output:
<img width="891" alt="image" src="https://github.com/fecgov/fecfile-web-api/assets/97105825/3723ab30-6aa0-4a1b-aae2-8d7cdec28e1a">
