### PR TITLE
Fix report migration failing on data issues

### DIFF
--- a/django-backend/fecfiler/reports/migrations/0008_remove_form1m_city_remove_form1m_committee_name_and_more.py
+++ b/django-backend/fecfiler/reports/migrations/0008_remove_form1m_city_remove_form1m_committee_name_and_more.py
@@ -11,42 +11,54 @@ def migrate_committee_data(apps, schema_editor):
     Form1m = apps.get_model("reports", "Form1M")  # noqa
 
     for form in Form24.objects.all():
-        report = Report.objects.get(form_24=form)
-        report.street_1 = form.street_1
-        report.street_2 = form.street_2
-        report.city = form.city
-        report.state = form.state
-        report.zip = form.zip
-        report.save()
+        report = Report.objects.filter(form_24=form).first()
+        if report is not None:
+            report.street_1 = form.street_1
+            report.street_2 = form.street_2
+            report.city = form.city
+            report.state = form.state
+            report.zip = form.zip
+            report.save()
+        else:
+            print("Report not found for ", form)
 
     for form in Form3x.objects.all():
-        report = Report.objects.get(form_3x=form)
-        report.street_1 = form.street_1
-        report.street_2 = form.street_2
-        report.city = form.city
-        report.state = form.state
-        report.zip = form.zip
-        report.save()
+        report = Report.objects.filter(form_3x=form).first()
+        if report is not None:
+            report.street_1 = form.street_1
+            report.street_2 = form.street_2
+            report.city = form.city
+            report.state = form.state
+            report.zip = form.zip
+            report.save()
+        else:
+            print("Report not found for ", form)
 
     for form in Form99.objects.all():
-        report = Report.objects.get(form_99=form)
-        report.committee_name = form.committee_name
-        report.street_1 = form.street_1
-        report.street_2 = form.street_2
-        report.city = form.city
-        report.state = form.state
-        report.zip = form.zip
-        report.save()
+        report = Report.objects.filter(form_99=form).first()
+        if report is not None:
+            report.committee_name = form.committee_name
+            report.street_1 = form.street_1
+            report.street_2 = form.street_2
+            report.city = form.city
+            report.state = form.state
+            report.zip = form.zip
+            report.save()
+        else:
+            print("Report not found for ", form)
 
     for form in Form1m.objects.all():
-        report = Report.objects.get(form_1m=form)
-        report.committee_name = form.committee_name
-        report.street_1 = form.street_1
-        report.street_2 = form.street_2
-        report.city = form.city
-        report.state = form.state
-        report.zip = form.zip
-        report.save()
+        report = Report.objects.filter(form_1m=form).first()
+        if report is not None:
+            report.committee_name = form.committee_name
+            report.street_1 = form.street_1
+            report.street_2 = form.street_2
+            report.city = form.city
+            report.state = form.state
+            report.zip = form.zip
+            report.save()
+        else:
+            print("Report not found for ", form)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
When deploying release sprint-41 to STAGE, the report migration 0008_remove_form1m_city_remove_form1m_committee_name_and_more was failing and failing the deployment.

The issue failing the migration is the STAGE database has reports_form* tables that contain records that don't have linked reports_report records.

Here are the form records missing links to reports on STAGE:

- Report not found for Form24 object (8212e535-f9fc-4efd-8aef-e3d92b903ba4)
- Report not found for Form24 object (780448d8-c493-4cdc-90f6-038b4dcdd6d1)
- Report not found for Form24 object (507e58d7-b4ab-4506-8b54-c4582c91cd25)
- Report not found for Form3X object (b0586e9a-3fce-4459-b69e-dd9f994d9c76)
- Report not found for Form3X object (925178b0-1568-435d-b347-05a622e8b645)
- Report not found for Form3X object (91d6ed2f-a955-46a4-b5b8-9db83c2acfd9)
- Report not found for Form3X object (20c82225-39ec-43ff-9d2f-976b4c0b22d5)
- Report not found for Form99 object (d3535a10-d359-4473-8916-425bc7bc6b24)
- Report not found for Form99 object (abe57a0c-4e02-4f82-bf30-7b7b7f81addb)
- Report not found for Form1M object (2d62d321-7f8d-4e86-a6bf-6f8a687ef6ed)

The follow on tasks below need to be performed:

1. Review the new report delete functionality to see if this data corruption is from old code and confirm it is not still happening.
2. Remove the orphaned form records from STAGE.
3. Review PROD for orphaned form records and remove them.

