### PR TITLE
Patch .fec serialization

### DIFF
--- a/django-backend/fecfiler/web_services/dot_fec/dot_fec_serializer.py
+++ b/django-backend/fecfiler/web_services/dot_fec/dot_fec_serializer.py
@@ -48,7 +48,7 @@ def default_serializer(model_instance, field_name, mapping):
     "None", thus the falsy condition
     """
     value = get_value_from_path(model_instance, mapping.get("path", None) or field_name)
-    return str(value) if value else ""
+    return str(value) if value is not None else ""
 
 
 """A map of model field types to their serializers.
@@ -89,9 +89,11 @@ def serialize_instance(schema_name, instance):
     column_sequences, row_length = extract_row_config(schema_name)
     field_mappings = get_field_mappings(schema_name)
     row = [
-        serialize_field(instance, column_sequences[column_index + 1], field_mappings)
-        if (column_index + 1) in column_sequences
-        else ""
+        (
+            serialize_field(instance, column_sequences[column_index + 1], field_mappings)
+            if (column_index + 1) in column_sequences
+            else ""
+        )
         for column_index in range(0, row_length)
     ]
     return FS_STR.join(row)

--- a/django-backend/fecfiler/web_services/dot_fec/test_dot_fec_serializer.py
+++ b/django-backend/fecfiler/web_services/dot_fec/test_dot_fec_serializer.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 import datetime
+from decimal import Decimal
 from .dot_fec_serializer import (
     serialize_field,
     serialize_instance,
@@ -61,8 +62,15 @@ class DotFECSerializerTestCase(TestCase):
             self.f3x, "L6b_cash_on_hand_beginning_period", f3x_field_mappings
         )
         self.assertEqual(serialized_numeric, "6.00")
-        serialized_numeric_undefined = serialize_field(
-            Report(), "L6b_cash_on_hand_beginning_period", f3x_field_mappings
+        self.f3x.form_3x.L6b_cash_on_hand_beginning_period = Decimal("0.00")
+        serialized_numeric_0 = serialize_field(  # 0.00 should be serialized as 0.00
+            self.f3x, "L6b_cash_on_hand_beginning_period", f3x_field_mappings
+        )
+        self.assertEqual(serialized_numeric_0, "0.00")
+        serialized_numeric_undefined = (
+            serialize_field(  # undefined should be serialized as ""
+                Report(), "L6b_cash_on_hand_beginning_period", f3x_field_mappings
+            )
         )
         self.assertEqual(serialized_numeric_undefined, "")
 

--- a/django-backend/fecfiler/web_services/summary/summary.py
+++ b/django-backend/fecfiler/web_services/summary/summary.py
@@ -248,7 +248,7 @@ class SummaryService:
             column_a["line_6b"] = self.report.form_3x.L6a_cash_on_hand_jan_1_ytd
 
         # if we have cash on hand values
-        if column_a.get("line_6b") != None and column_b.get("line_6a") != None:
+        if column_a.get("line_6b") is not None and column_b.get("line_6a") is not None:
             column_a["line_6d"] = column_a["line_6b"] + column_a["line_6c"]
             column_a["line_8"] = column_a["line_6d"] - column_a["line_7"]
             column_b["line_6d"] = column_b["line_6a"] + column_b["line_6c"]

--- a/django-backend/fecfiler/web_services/summary/summary.py
+++ b/django-backend/fecfiler/web_services/summary/summary.py
@@ -248,7 +248,7 @@ class SummaryService:
             column_a["line_6b"] = self.report.form_3x.L6a_cash_on_hand_jan_1_ytd
 
         # if we have cash on hand values
-        if "line_6b" in column_a and "line_6a" in column_b:
+        if column_a.get("line_6b") != None and column_b.get("line_6a") != None:
             column_a["line_6d"] = column_a["line_6b"] + column_a["line_6c"]
             column_a["line_8"] = column_a["line_6d"] - column_a["line_7"]
             column_b["line_6d"] = column_b["line_6a"] + column_b["line_6c"]

--- a/django-backend/fecfiler/web_services/summary/test_summary.py
+++ b/django-backend/fecfiler/web_services/summary/test_summary.py
@@ -212,3 +212,11 @@ class F3XReportTestCase(TestCase):
         summary_service = SummaryService(f3x)
         summary_a, _ = summary_service.calculate_summary()
         self.assertTrue("line_8" in summary_a)
+
+    def test_report_with_none_cash_on_hand(self):
+        f3x = Report.objects.get(id="b6d60d2d-d926-4e89-ad4b-c47d152a66ae")
+        f3x.form_3x.L6a_cash_on_hand_jan_1_ytd = None
+        f3x.form_3x.save()
+        summary_service = SummaryService(f3x)
+        summary_a, _ = summary_service.calculate_summary()
+        self.assertFalse("line_8" in summary_a)


### PR DESCRIPTION
Fix for the issue when calculating fields associated with the cash on hand when lines 6a or 6b did not have a value.