### PR TITLE
feature/632 - ensure deployments fail when migration fails

### DIFF
--- a/bin/run-api.sh
+++ b/bin/run-api.sh
@@ -1,6 +1,6 @@
 cd django-backend
 
 # Run migrations and application
-./manage.py migrate --no-input --traceback --verbosity 3 > migrate.out &&
+./manage.py migrate --no-input --traceback --verbosity 3 &&
 	python manage.py create_committee_views &&
-	gunicorn --bind 0.0.0.0:8080 fecfiler.wsgi -w 9
+	exec gunicorn --bind 0.0.0.0:8080 fecfiler.wsgi -w 9


### PR DESCRIPTION
Issue #632

I was able to reproduce this issue in dev several weeks ago, but I am no longer able to do so.  A failing migration causes the api not to start and thus the health check and deployment to fail and be reverted with zero downtime now as expected.

One thing to note is that Cloud.gov has recently updated its Cloud Foundry instances to later versions which may explain the discrepancy.  

For this PR, I added the [Cloud Foundry recommendation ](https://docs.cloudfoundry.org/devguide/deploy-apps/manifest-attributes.html#-command) of prefixing our final command with exec to ensure signals are propagated back to the app.