### PR TITLE
Feature/901 dot fec crash fix

### DIFF
--- a/django-backend/fecfiler/reports/models.py
+++ b/django-backend/fecfiler/reports/models.py
@@ -160,6 +160,10 @@ TABLE_TO_FORM = {
     "form_1m": "F1M",
 }
 
+FORMS_TO_CALCULATE = [
+    "F3X",
+]
+
 
 def update_recalculation(report: Report):
     if report:

--- a/django-backend/fecfiler/reports/tests/test_models.py
+++ b/django-backend/fecfiler/reports/tests/test_models.py
@@ -41,7 +41,7 @@ class ReportModelTestCase(TestCase):
         self.assertEquals(f24_report.form_type, "F24A")
 
     def test_delete(self):
-        f24_report = create_form24(self.committee, "2024-01-01", "2024-02-01", {})
+        f24_report = create_form24(self.committee, {})
         f24_report_id = f24_report.id
         f24_id = f24_report.form_24.id
         f3x_report = create_form3x(self.committee, "2024-01-01", "2024-02-01", {})

--- a/django-backend/fecfiler/reports/tests/utils.py
+++ b/django-backend/fecfiler/reports/tests/utils.py
@@ -13,8 +13,10 @@ def create_form3x(committee, coverage_from, coverage_through, data={}):
 def create_form24(committee, data={}):
     return create_test_report(Form24, committee, data=data)
 
+
 def create_form99(committee, data={}):
     return create_test_report(Form99, committee, data=data)
+
 
 def create_form1m(committee, data={}):
     return create_test_report(Form1M, committee, data=data)

--- a/django-backend/fecfiler/reports/tests/utils.py
+++ b/django-backend/fecfiler/reports/tests/utils.py
@@ -11,7 +11,13 @@ def create_form3x(committee, coverage_from, coverage_through, data={}):
 
 
 def create_form24(committee, data={}):
-    return create_test_report(Form24, committee, None, None, data)
+    return create_test_report(Form24, committee, data=data)
+
+def create_form99(committee, data={}):
+    return create_test_report(Form99, committee, data=data)
+
+def create_form1m(committee, data={}):
+    return create_test_report(Form1M, committee, data=data)
 
 
 def create_test_report(

--- a/django-backend/fecfiler/reports/tests/utils.py
+++ b/django-backend/fecfiler/reports/tests/utils.py
@@ -6,16 +6,16 @@ from fecfiler.reports.form_24.models import Form24
 from fecfiler.reports.form_99.models import Form99
 
 
-def create_form3x(committee, coverage_from, coverage_through, data):
+def create_form3x(committee, coverage_from, coverage_through, data={}):
     return create_test_report(Form3X, committee, coverage_from, coverage_through, data)
 
 
-def create_form24(committee, coverage_from, coverage_through, data):
-    return create_test_report(Form24, committee, coverage_from, coverage_through, data)
+def create_form24(committee, data={}):
+    return create_test_report(Form24, committee, None, None, data)
 
 
 def create_test_report(
-    form, committee, coverage_from=None, coverage_through=None, data=None
+    form, committee, coverage_from=None, coverage_through=None, data={}
 ):
     form_object = create_form(form, data)
     report = Report.objects.create(

--- a/django-backend/fecfiler/web_services/summary/tasks.py
+++ b/django-backend/fecfiler/web_services/summary/tasks.py
@@ -21,6 +21,10 @@ class CalculationState(Enum):
 
 
 def get_reports_to_calculate(primary_report):
+    coverage_from_date = primary_report.coverage_from_date
+    if coverage_from_date is None:
+        return primary_report
+
     report_year = primary_report.coverage_from_date.year
     reports_to_recalculate = Report.objects.filter(
         ~Q(calculation_status=CalculationState.SUCCEEDED),

--- a/django-backend/fecfiler/web_services/summary/tasks.py
+++ b/django-backend/fecfiler/web_services/summary/tasks.py
@@ -20,7 +20,7 @@ class CalculationState(Enum):
         return str(self.value)
 
 
-def get_reports_to_calculate(primary_report):
+def get_reports_to_calculate_by_coverage_date(primary_report):
     if not hasattr(primary_report, "coverage_from_date"):
         return primary_report
 
@@ -46,7 +46,9 @@ def calculate_summary(report_id):
     if primary_report.get_form_name() not in FORMS_TO_CALCULATE:
         return primary_report.id
 
-    reports_to_recalculate = get_reports_to_calculate(primary_report)
+    reports_to_recalculate = get_reports_to_calculate_by_coverage_date(
+        primary_report
+    )
     calculation_token = uuid.uuid4()
     reports_to_recalculate.update(
         calculation_token=calculation_token,

--- a/django-backend/fecfiler/web_services/test_views.py
+++ b/django-backend/fecfiler/web_services/test_views.py
@@ -5,7 +5,7 @@ from fecfiler.web_services.views import WebServicesViewSet
 from fecfiler.user.models import User
 from fecfiler.committee_accounts.models import CommitteeAccount
 from fecfiler.committee_accounts.views import create_committee_view
-from fecfiler.reports.tests.utils import create_form3x
+from fecfiler.reports.tests.utils import create_form3x, create_form24
 from fecfiler.web_services.summary.tasks import CalculationState
 
 from unittest.mock import patch
@@ -54,6 +54,18 @@ class WebServicesViewSetTest(TestCase):
         report.refresh_from_db()
         # assert that summary was caclulated
         self.assertEqual(report.form_3x.L8_cash_on_hand_at_close_period, 1)
+
+    def test_create_dot_fec_form_24(self):
+        report = create_form24(self.committee)
+        request = self.factory.post(
+            "/api/v1/web-services/dot-fec/", {"report_id": report.id}
+        )
+        force_authenticate(request, self.user)
+        request.session = {"committee_uuid": self.committee.id}
+
+        response = WebServicesViewSet.as_view({"post": "create_dot_fec"})(request)
+        self.assertEqual(response.status_code, 200)
+        report.refresh_from_db()
 
     def test_submit_to_webprint(self):
         report = create_form3x(

--- a/django-backend/fecfiler/web_services/test_views.py
+++ b/django-backend/fecfiler/web_services/test_views.py
@@ -5,7 +5,7 @@ from fecfiler.web_services.views import WebServicesViewSet
 from fecfiler.user.models import User
 from fecfiler.committee_accounts.models import CommitteeAccount
 from fecfiler.committee_accounts.views import create_committee_view
-from fecfiler.reports.tests.utils import create_form3x, create_form24
+from fecfiler.reports.tests.utils import create_form3x, create_form24, create_form99, create_form1m
 from fecfiler.web_services.summary.tasks import CalculationState
 
 from unittest.mock import patch
@@ -57,6 +57,30 @@ class WebServicesViewSetTest(TestCase):
 
     def test_create_dot_fec_form_24(self):
         report = create_form24(self.committee)
+        request = self.factory.post(
+            "/api/v1/web-services/dot-fec/", {"report_id": report.id}
+        )
+        force_authenticate(request, self.user)
+        request.session = {"committee_uuid": self.committee.id}
+
+        response = WebServicesViewSet.as_view({"post": "create_dot_fec"})(request)
+        self.assertEqual(response.status_code, 200)
+        report.refresh_from_db()
+
+    def test_create_dot_fec_form_99(self):
+        report = create_form99(self.committee)
+        request = self.factory.post(
+            "/api/v1/web-services/dot-fec/", {"report_id": report.id}
+        )
+        force_authenticate(request, self.user)
+        request.session = {"committee_uuid": self.committee.id}
+
+        response = WebServicesViewSet.as_view({"post": "create_dot_fec"})(request)
+        self.assertEqual(response.status_code, 200)
+        report.refresh_from_db()
+
+    def test_create_dot_fec_form_1m(self):
+        report = create_form1m(self.committee)
         request = self.factory.post(
             "/api/v1/web-services/dot-fec/", {"report_id": report.id}
         )

--- a/django-backend/fecfiler/web_services/test_views.py
+++ b/django-backend/fecfiler/web_services/test_views.py
@@ -5,7 +5,9 @@ from fecfiler.web_services.views import WebServicesViewSet
 from fecfiler.user.models import User
 from fecfiler.committee_accounts.models import CommitteeAccount
 from fecfiler.committee_accounts.views import create_committee_view
-from fecfiler.reports.tests.utils import create_form3x, create_form24, create_form99, create_form1m
+from fecfiler.reports.tests.utils import (
+	create_form3x, create_form24, create_form99, create_form1m
+)
 from fecfiler.web_services.summary.tasks import CalculationState
 
 from unittest.mock import patch

--- a/django-backend/fecfiler/web_services/test_views.py
+++ b/django-backend/fecfiler/web_services/test_views.py
@@ -6,7 +6,7 @@ from fecfiler.user.models import User
 from fecfiler.committee_accounts.models import CommitteeAccount
 from fecfiler.committee_accounts.views import create_committee_view
 from fecfiler.reports.tests.utils import (
-	create_form3x, create_form24, create_form99, create_form1m
+    create_form3x, create_form24, create_form99, create_form1m
 )
 from fecfiler.web_services.summary.tasks import CalculationState
 

--- a/django-backend/fecfiler/web_services/views.py
+++ b/django-backend/fecfiler/web_services/views.py
@@ -15,7 +15,7 @@ from .serializers import ReportIdSerializer, SubmissionRequestSerializer
 from .renderers import DotFECRenderer
 from .web_service_storage import get_file
 from .models import DotFEC, UploadSubmission, WebPrintSubmission
-from fecfiler.reports.models import Report
+from fecfiler.reports.models import Report, FORMS_TO_CALCULATE
 from celery.result import AsyncResult
 
 import structlog
@@ -176,6 +176,6 @@ class WebServicesViewSet(viewsets.ViewSet):
         report = Report.objects.filter(
             id=report_id, committee_account_id=committee_uuid
         ).first()
-        if report.calculation_status != CalculationState.SUCCEEDED.value:
+        if report.get_form_name() in FORMS_TO_CALCULATE and report.calculation_status != CalculationState.SUCCEEDED.value:
             return calculate_summary.s(report_id)
         return None

--- a/django-backend/fecfiler/web_services/views.py
+++ b/django-backend/fecfiler/web_services/views.py
@@ -177,7 +177,7 @@ class WebServicesViewSet(viewsets.ViewSet):
             id=report_id, committee_account_id=committee_uuid
         ).first()
         if (
-            report.get_form_name() in FORMS_TO_CALCULATE 
+            report.get_form_name() in FORMS_TO_CALCULATE
             and report.calculation_status != CalculationState.SUCCEEDED.value
         ):
             return calculate_summary.s(report_id)

--- a/django-backend/fecfiler/web_services/views.py
+++ b/django-backend/fecfiler/web_services/views.py
@@ -176,6 +176,9 @@ class WebServicesViewSet(viewsets.ViewSet):
         report = Report.objects.filter(
             id=report_id, committee_account_id=committee_uuid
         ).first()
-        if report.get_form_name() in FORMS_TO_CALCULATE and report.calculation_status != CalculationState.SUCCEEDED.value:
+        if (
+            report.get_form_name() in FORMS_TO_CALCULATE 
+            and report.calculation_status != CalculationState.SUCCEEDED.value
+        ):
             return calculate_summary.s(report_id)
         return None


### PR DESCRIPTION
#901 

When creating .FEC files for forms 99, 1m, and 24, the API would crash.  This happened because the API would try to calculate summaries for those reports when that is not intended behavior.  Checks were put into place to avoid calculating summaries for reports outside of a list of acceptable forms (FORMS_TO_CALCULATE as found in the report models file)