### PR TITLE
feature/914 - make committee membership add new user case insensitive

### DIFF
--- a/django-backend/fecfiler/committee_accounts/test_views.py
+++ b/django-backend/fecfiler/committee_accounts/test_views.py
@@ -125,6 +125,29 @@ class CommitteeMemberViewSetTest(TestCase):
         self.assertEqual(response.data["email"], "test_user_0001@fec.gov")
         self.assertEqual(response.data["is_active"], True)
 
+    def test_add_membership_for_preexisting_user_email_case_test(self):
+        # This test covers a bug found where the email entered is treated
+        # as case when determining membership when it should not be.
+
+        view = CommitteeMembershipViewSet()
+        request = self.factory.get("/api/v1/committee-members/add-member")
+        request.user = self.user
+        request.session = {
+            "committee_uuid": UUID("11111111-2222-3333-4444-555555555555"),
+            "committee_id": "C01234567",
+        }
+        request.method = "POST"
+        request.data = {
+            "role": Membership.CommitteeRole.COMMITTEE_ADMINISTRATOR,
+            "email": "TEST_USER_0001@fec.gov",
+        }
+        view.request = request
+        response = view.add_member(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["email"], "test_user_0001@fec.gov")
+        self.assertEqual(response.data["is_active"], True)
+
     def test_add_membership_requires_correct_parameters(self):
         view = CommitteeMembershipViewSet()
         request = self.factory.get("/api/v1/committee-members/add-member")

--- a/django-backend/fecfiler/committee_accounts/views.py
+++ b/django-backend/fecfiler/committee_accounts/views.py
@@ -171,7 +171,7 @@ class CommitteeMembershipViewSet(CommitteeOwnedViewMixin, viewsets.ModelViewSet)
             )
 
         # Create new membership
-        user = User.objects.filter(email=email).first()
+        user = User.objects.filter(email__iexact=email).first()
 
         membership_args = {
             "committee_account": committee,

--- a/django-backend/fecfiler/user/managers.py
+++ b/django-backend/fecfiler/user/managers.py
@@ -10,8 +10,7 @@ class UserManager(AbstractUserManager):
 
         new_user = super().create_user(user_id, **obj_data)
         pending_memberships = Membership.objects.filter(
-            user=None,
-            pending_email=obj_data['email']
+            user=None, pending_email__iexact=obj_data["email"]
         )
 
         logger.info(


### PR DESCRIPTION
https://github.com/fecgov/fecfile-web-api/issues/914

Changed the check in two places for email which should be case insensitive
1) when a user record is created in the system and corresponding pending membership records are created
2) when membership records are created for an existing user