### PR TITLE
Release/sprint-43 hotfix for select-committee list length back into develop

### DIFF
--- a/django-backend/fecfiler/committee_accounts/views.py
+++ b/django-backend/fecfiler/committee_accounts/views.py
@@ -32,8 +32,13 @@ class CommitteeMemberListPagination(pagination.PageNumberPagination):
     page_size_query_param = "page_size"
 
 
+class CommitteePagination(pagination.PageNumberPagination):
+    page_size = 100
+
+
 class CommitteeViewSet(viewsets.GenericViewSet, mixins.ListModelMixin):
     serializer_class = CommitteeAccountSerializer
+    pagination_class = CommitteePagination
 
     def get_queryset(self):
         user = self.request.user


### PR DESCRIPTION
hotfix to allow select-committee list to be longer than 10 committees.