### PR TITLE
780 - Update API for custom domain

### DIFF
--- a/django-backend/fecfiler/middleware.py
+++ b/django-backend/fecfiler/middleware.py
@@ -1,0 +1,8 @@
+class HeaderMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        response['cache-control'] = "no-cache, no-store"
+        return response

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -110,8 +110,8 @@ TEMPLATES = [
     },
 ]
 
-CORS_ALLOWED_ORIGINS = [
-    env.get_credential("CORS_ALLOWED_ORIGINS", "http://localhost:4200")
+CORS_ALLOWED_ORIGIN_REGEXES = [
+    r"^https://(.*?).fecfile\.fec\.gov$"
 ]
 CORS_ALLOW_HEADERS = default_headers + ("enctype", "token")
 

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -82,6 +82,7 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
+    "fecfiler.middleware.HeaderMiddleware",
     "fecfiler.authentication.middleware.TimeoutMiddleware.TimeoutMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -111,7 +112,13 @@ TEMPLATES = [
 CORS_ALLOWED_ORIGIN_REGEXES = [
     r"^https://(.*?).fecfile\.fec\.gov$"
 ]
-CORS_ALLOW_HEADERS = default_headers + ("enctype", "token")
+
+CORS_ALLOW_HEADERS = (
+    *default_headers,
+    "enctype",
+    "token",
+    "cache-control",
+)
 
 CORS_ALLOW_CREDENTIALS = True
 

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -27,9 +27,7 @@ KEY_VALUE = "KEY_VALUE"
 LOG_FORMAT = env.get_credential("LOG_FORMAT", LINE)
 
 CSRF_COOKIE_DOMAIN = env.get_credential("FFAPI_COOKIE_DOMAIN")
-CSRF_TRUSTED_ORIGINS = [
-    env.get_credential("CSRF_TRUSTED_ORIGINS", "http://localhost:4200")
-]
+CSRF_TRUSTED_ORIGINS = ["https://*.fecfile.fec.gov"]
 
 """
 Enables alternative log in method.

--- a/django-backend/fecfiler/settings/local.py
+++ b/django-backend/fecfiler/settings/local.py
@@ -3,6 +3,7 @@ from .base import *  # NOSONAR # noqa: F401, F403
 # These settings are for local development only.
 
 CORS_ALLOWED_ORIGIN_REGEXES.append("http://localhost:4200")  # NOSONAR # noqa: F405
+CSRF_TRUSTED_ORIGINS.append("http://localhost:4200")  # NOSONAR # noqa: F405
 
 try:
     from .local import *  # NOSONAR # noqa: F401, F403

--- a/django-backend/fecfiler/settings/local.py
+++ b/django-backend/fecfiler/settings/local.py
@@ -2,6 +2,7 @@ from .base import *  # NOSONAR # noqa: F401, F403
 
 # These settings are for local development only.
 
+CORS_ALLOWED_ORIGIN_REGEXES.append("http://localhost:4200")  # NOSONAR # noqa: F405
 
 try:
     from .local import *  # NOSONAR # noqa: F401, F403

--- a/django-backend/fecfiler/settings/production.py
+++ b/django-backend/fecfiler/settings/production.py
@@ -11,4 +11,4 @@ SESSION_COOKIE_SECURE = True
 SESSION_COOKIE_HTTPONLY = True
 CSRF_COOKIE_SECURE = True
 
-ALLOWED_HOSTS = [".fec.gov", ".app.cloud.gov"]
+ALLOWED_HOSTS = [".fecfile.fec.gov"]

--- a/manifests/manifest-dev-api.yml
+++ b/manifests/manifest-dev-api.yml
@@ -17,7 +17,6 @@ applications:
     env:
       DISABLE_COLLECTSTATIC: 1
       DJANGO_SETTINGS_MODULE: fecfiler.settings.production
-      CORS_ALLOWED_ORIGINS: https://fecfile-web-app-dev.app.cloud.gov
       CSRF_TRUSTED_ORIGINS: https://fecfile-web-app-dev.app.cloud.gov
       FFAPI_COOKIE_DOMAIN: app.cloud.gov
       LOGIN_REDIRECT_CLIENT_URL: https://fecfile-web-app-dev.app.cloud.gov

--- a/manifests/manifest-dev-api.yml
+++ b/manifests/manifest-dev-api.yml
@@ -17,10 +17,10 @@ applications:
     env:
       DISABLE_COLLECTSTATIC: 1
       DJANGO_SETTINGS_MODULE: fecfiler.settings.production
-      FFAPI_COOKIE_DOMAIN: app.cloud.gov
-      LOGIN_REDIRECT_CLIENT_URL: https://fecfile-web-app-dev.app.cloud.gov
-      LOGIN_REDIRECT_SERVER_URL: https://fecfile-web-api-dev.app.cloud.gov/api/v1/auth/login-redirect
-      LOGOUT_REDIRECT_URL: https://fecfile-web-api-dev.app.cloud.gov/api/v1/auth/logout-redirect
+      FFAPI_COOKIE_DOMAIN: fecfile.fec.gov
+      LOGIN_REDIRECT_CLIENT_URL: https://dev-api.fecfile.fec.gov
+      LOGIN_REDIRECT_SERVER_URL: https://dev-api.fecfile.fec.gov/api/v1/auth/login-redirect
+      LOGOUT_REDIRECT_URL: https://dev-api.fecfile.fec.gov/api/v1/auth/logout-redirect
       FEC_API: https://api.open.fec.gov/v1/
       SESSION_COOKIE_AGE: 64800
       BP_PIP_VERSION: latest

--- a/manifests/manifest-dev-api.yml
+++ b/manifests/manifest-dev-api.yml
@@ -17,7 +17,6 @@ applications:
     env:
       DISABLE_COLLECTSTATIC: 1
       DJANGO_SETTINGS_MODULE: fecfiler.settings.production
-      CSRF_TRUSTED_ORIGINS: https://fecfile-web-app-dev.app.cloud.gov
       FFAPI_COOKIE_DOMAIN: app.cloud.gov
       LOGIN_REDIRECT_CLIENT_URL: https://fecfile-web-app-dev.app.cloud.gov
       LOGIN_REDIRECT_SERVER_URL: https://fecfile-web-api-dev.app.cloud.gov/api/v1/auth/login-redirect

--- a/manifests/manifest-prod-api.yml
+++ b/manifests/manifest-prod-api.yml
@@ -17,7 +17,6 @@ applications:
     env:
       DISABLE_COLLECTSTATIC: 1
       DJANGO_SETTINGS_MODULE: fecfiler.settings.production
-      CSRF_TRUSTED_ORIGINS: https://fecfile-web-app-prod.app.cloud.gov
       FFAPI_COOKIE_DOMAIN: app.cloud.gov
       LOGIN_REDIRECT_CLIENT_URL: https://fecfile-web-app-prod.app.cloud.gov
       LOGIN_REDIRECT_SERVER_URL: https://fecfile-web-api-prod.app.cloud.gov/api/v1/auth/login-redirect

--- a/manifests/manifest-prod-api.yml
+++ b/manifests/manifest-prod-api.yml
@@ -17,10 +17,10 @@ applications:
     env:
       DISABLE_COLLECTSTATIC: 1
       DJANGO_SETTINGS_MODULE: fecfiler.settings.production
-      FFAPI_COOKIE_DOMAIN: app.cloud.gov
-      LOGIN_REDIRECT_CLIENT_URL: https://fecfile-web-app-prod.app.cloud.gov
-      LOGIN_REDIRECT_SERVER_URL: https://fecfile-web-api-prod.app.cloud.gov/api/v1/auth/login-redirect
-      LOGOUT_REDIRECT_URL: https://fecfile-web-api-prod.app.cloud.gov/api/v1/auth/logout-redirect
+      FFAPI_COOKIE_DOMAIN: fecfile.fec.gov
+      LOGIN_REDIRECT_CLIENT_URL: https://api.fecfile.fec.gov
+      LOGIN_REDIRECT_SERVER_URL: https://api.fecfile.fec.gov/api/v1/auth/login-redirect
+      LOGOUT_REDIRECT_URL: https://api.fecfile.fec.gov/api/v1/auth/logout-redirect
       FEC_API: https://api.open.fec.gov/v1/
       SESSION_COOKIE_AGE: 64800
       BP_PIP_VERSION: latest

--- a/manifests/manifest-prod-api.yml
+++ b/manifests/manifest-prod-api.yml
@@ -17,7 +17,6 @@ applications:
     env:
       DISABLE_COLLECTSTATIC: 1
       DJANGO_SETTINGS_MODULE: fecfiler.settings.production
-      CORS_ALLOWED_ORIGINS: https://fecfile-web-app-prod.app.cloud.gov
       CSRF_TRUSTED_ORIGINS: https://fecfile-web-app-prod.app.cloud.gov
       FFAPI_COOKIE_DOMAIN: app.cloud.gov
       LOGIN_REDIRECT_CLIENT_URL: https://fecfile-web-app-prod.app.cloud.gov

--- a/manifests/manifest-stage-api.yml
+++ b/manifests/manifest-stage-api.yml
@@ -17,10 +17,10 @@ applications:
     env:
       DISABLE_COLLECTSTATIC: 1
       DJANGO_SETTINGS_MODULE: fecfiler.settings.production
-      FFAPI_COOKIE_DOMAIN: app.cloud.gov
-      LOGIN_REDIRECT_CLIENT_URL: https://fecfile-web-app-stage.app.cloud.gov
-      LOGIN_REDIRECT_SERVER_URL: https://fecfile-web-api-stage.app.cloud.gov/api/v1/auth/login-redirect
-      LOGOUT_REDIRECT_URL: https://fecfile-web-api-stage.app.cloud.gov/api/v1/auth/logout-redirect
+      FFAPI_COOKIE_DOMAIN: fecfile.fec.gov
+      LOGIN_REDIRECT_CLIENT_URL: https://stage-api.fecfile.fec.gov
+      LOGIN_REDIRECT_SERVER_URL: https://stage-api.fecfile.fec.gov/api/v1/auth/login-redirect
+      LOGOUT_REDIRECT_URL: https://stage-api.fecfile.fec.gov/api/v1/auth/logout-redirect
       FEC_API: https://api.open.fec.gov/v1/
       SESSION_COOKIE_AGE: 64800
       BP_PIP_VERSION: latest

--- a/manifests/manifest-stage-api.yml
+++ b/manifests/manifest-stage-api.yml
@@ -17,7 +17,6 @@ applications:
     env:
       DISABLE_COLLECTSTATIC: 1
       DJANGO_SETTINGS_MODULE: fecfiler.settings.production
-      CORS_ALLOWED_ORIGINS: https://fecfile-web-app-stage.app.cloud.gov
       CSRF_TRUSTED_ORIGINS: https://fecfile-web-app-stage.app.cloud.gov
       FFAPI_COOKIE_DOMAIN: app.cloud.gov
       LOGIN_REDIRECT_CLIENT_URL: https://fecfile-web-app-stage.app.cloud.gov

--- a/manifests/manifest-stage-api.yml
+++ b/manifests/manifest-stage-api.yml
@@ -17,7 +17,6 @@ applications:
     env:
       DISABLE_COLLECTSTATIC: 1
       DJANGO_SETTINGS_MODULE: fecfiler.settings.production
-      CSRF_TRUSTED_ORIGINS: https://fecfile-web-app-stage.app.cloud.gov
       FFAPI_COOKIE_DOMAIN: app.cloud.gov
       LOGIN_REDIRECT_CLIENT_URL: https://fecfile-web-app-stage.app.cloud.gov
       LOGIN_REDIRECT_SERVER_URL: https://fecfile-web-api-stage.app.cloud.gov/api/v1/auth/login-redirect

--- a/performance-testing/README.md
+++ b/performance-testing/README.md
@@ -46,7 +46,7 @@ Run the script with the `-h` flag for additional information.
 
 2. Set the target API service for testing in [docker-compose.yml](https://github.com/fecgov/fecfile-web-api/blob/develop/docker-compose.yml#L118):
 - As an example, this is what you would set in order to target DEV:
-  - `-f /mnt/locust/locust_run.py --master -H https://fecfile-web-api-dev.app.cloud.gov`
+  - `-f /mnt/locust/locust_run.py --master -H https://dev-api.fecfile.fec.gov`
 
 ## Running Tests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ decorator==5.1.1
 dj-database-url==1.3.0
 dj-static==0.0.6
 Django==4.2.11  # when updating this, also update requirements/tox versions in fecgov/mozilla_django_oidc
-django-cors-headers==3.13.0
+django-cors-headers==4.3.1
 django-storages==1.13.1
 djangorestframework==3.14.0
 git+https://github.com/fecgov/fecfile-validate@0f8b966b623fbca644aebb2054fe4829eb0e0a93#egg=fecfile_validate&subdirectory=fecfile_validate_python

--- a/tasks.py
+++ b/tasks.py
@@ -10,6 +10,7 @@ env = cfenv.AppEnv()
 
 APP_NAME = "fecfile-web-api"
 WEB_SERVICES_NAME = "fecfile-web-services"
+PROXY_NAME = "fecfile-api-proxy"
 ORG_NAME = "fec-fecfileonline-prototyping"
 
 MANIFEST_LABEL = {
@@ -195,7 +196,7 @@ def deploy(ctx, space=None, branch=None, login=False, help=False):
 
     # Allow proxy to connect to api via internal route
     add_network_policy = ctx.run(
-        "cf add-network-policy fecfile-api-proxy fecfile-web-api",
+        f"cf add-network-policy {PROXY_NAME} {APP_NAME}",
         echo=True,
         warn=True,
     )


### PR DESCRIPTION
## Summary

Issue [api#780](https://github.com/fecgov/fecfile-web-api/issues/780)
  
Update API for custom domain:

- CORS, CSRF Allow all *.fecfile.fec.gov origins
- Update django-cors-headers version
- Update domain to fecfile.fec.gov
- Add header middleware to set cache-control header
- Allow cache-control header
- Minor improvment to deploy task


