### PR TITLE
feature/1442 - Pinning sqlparse to 0.5.0 for snyk security check

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,6 @@ git+https://github.com/fecgov/mozilla-django-oidc.git@5a813c15fba5463a2907b2e22a
 zeep==4.2.1
 django-structlog[celery]==7.1.0
 rich==13.7.0
+
+# Pinning sqlparse to 0.5.0 as it is a sub-dependency that needs to be upgraded for security
+sqlparse==0.5.0


### PR DESCRIPTION
Issue [FECFILE-1442](https://fecgov.atlassian.net/browse/FECFILE-1442)