### PR TITLE
feature/892 - migrate mozilla-django-oidc items into api repo

### DIFF
--- a/django-backend/fecfiler/authentication/backends.py
+++ b/django-backend/fecfiler/authentication/backends.py
@@ -189,7 +189,7 @@ class OIDCAuthenticationBackend(ModelBackend):
         )
         token_payload = {
             "client_assertion": encoded_jwt,
-            "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",  # noqa
             "code": payload.get("code"),
             "grant_type": "authorization_code",
         }

--- a/django-backend/fecfiler/authentication/backends.py
+++ b/django-backend/fecfiler/authentication/backends.py
@@ -1,0 +1,299 @@
+"""
+This source code has been lifted from the mozilla-django-oidc
+project:
+https://mozilla-django-oidc.readthedocs.io/en/stable/index.html#
+https://github.com/mozilla/mozilla-django-oidc/tree/main
+
+It has been modified in places to meet the needs of the project and
+the original version can be found on Github:
+https://github.com/mozilla/mozilla-django-oidc/blob/main/mozilla_django_oidc/auth.py
+
+"""
+
+import json
+import logging
+import requests
+
+# logindotgov-oidc
+import secrets
+import time
+import jwt
+
+# /logindotgov-oidc
+from django.contrib.auth import get_user_model
+from django.contrib.auth.backends import ModelBackend
+from django.core.exceptions import SuspiciousOperation
+from django.urls import reverse
+from django.utils.encoding import force_bytes, smart_bytes, smart_str
+from josepy.jwk import JWK
+from josepy.jws import JWS, Header
+from requests.exceptions import HTTPError
+
+from fecfiler.settings import (
+    OIDC_OP_UNIQUE_IDENTIFIER,
+    OIDC_RP_UNIQUE_IDENTIFIER,
+    OIDC_RP_SIGN_ALGO,
+    OIDC_OP_JWKS_ENDPOINT,
+    OIDC_RP_CLIENT_ID,
+    OIDC_OP_TOKEN_ENDPOINT,
+    OIDC_RP_CLIENT_SECRET,
+    OIDC_OP_USER_ENDPOINT,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+class OIDCAuthenticationBackend(ModelBackend):
+    """Override Django's authentication."""
+
+    def __init__(self, *args, **kwargs):
+        self.UserModel = get_user_model()
+
+    def get_idp_unique_id_value(self, claims):
+        """Helper method to clarify whether we're using OP or RP unique ID"""
+        return claims.get(OIDC_OP_UNIQUE_IDENTIFIER)
+
+    def filter_users_by_claims(self, claims):
+        """Return all users matching the specified unique identifier."""
+        # Get the unique ID value from IDP
+        unique_identifier_value = self.get_idp_unique_id_value(claims)
+        if not unique_identifier_value:
+            return self.UserModel.objects.none()
+        # Use the app label to filter
+        filter_label = OIDC_RP_UNIQUE_IDENTIFIER + "__iexact"
+        kwargs = {filter_label: unique_identifier_value}
+        filtered_users = self.UserModel.objects.filter(**kwargs)
+
+        return filtered_users
+
+    def verify_claims(self, claims):
+        """Verify the provided claims to decide if authentication should be allowed."""
+        return "email" in claims
+
+    def create_user(self, claims):
+        """Return object for a newly created user account."""
+        email = claims.get("email")
+        username = self.get_username(claims)
+        return self.UserModel.objects.create_user(username, email=email)
+
+    def get_username(self, claims):
+        """Generate username based on claims."""
+        return self.get_idp_unique_id_value(claims)
+
+    def update_user(self, user, claims):
+        """Update existing user with new email, if necessary save, and return user"""
+
+        user.email = claims.get("email")
+        user.save()
+        return user
+
+    def _verify_jws(self, payload, key):
+        """Verify the given JWS payload with the given key and return the payload"""
+        jws = JWS.from_compact(payload)
+
+        try:
+            alg = jws.signature.combined.alg.name
+        except KeyError:
+            msg = "No alg value found in header"
+            raise SuspiciousOperation(msg)
+
+        if alg != OIDC_RP_SIGN_ALGO:
+            msg = (
+                "The provider algorithm {!r} does not match the client's "
+                "OIDC_RP_SIGN_ALGO.".format(alg)
+            )
+            raise SuspiciousOperation(msg)
+
+        if isinstance(key, str):
+            # Use smart_bytes here since the key string comes from settings.
+            jwk = JWK.load(smart_bytes(key))
+        else:
+            # The key is a json returned from the IDP JWKS endpoint.
+            jwk = JWK.from_json(key)
+
+        if not jws.verify(jwk):
+            msg = "JWS token verification failed."
+            raise SuspiciousOperation(msg)
+
+        return jws.payload
+
+    def retrieve_matching_jwk(self, token):
+        """Get the signing key by exploring the JWKS endpoint of the OP."""
+        response_jwks = requests.get(
+            OIDC_OP_JWKS_ENDPOINT,
+            verify=True,
+            timeout=None,
+            proxies=None,
+        )
+        response_jwks.raise_for_status()
+        jwks = response_jwks.json()
+
+        # Compute the current header from the given token to find a match
+        jws = JWS.from_compact(token)
+        json_header = jws.signature.protected
+        header = Header.json_loads(json_header)
+
+        key = None
+        for jwk in jwks["keys"]:
+            if jwk["kid"] != smart_str(header.kid):
+                continue
+            if "alg" in jwk and jwk["alg"] != smart_str(header.alg):
+                continue
+            key = jwk
+        if key is None:
+            raise SuspiciousOperation("Could not find a valid JWKS.")
+        return key
+
+    def get_payload_data(self, token, key):
+        """Helper method to get the payload of the JWT token."""
+        return self._verify_jws(token, key)
+
+    def verify_token(self, token, **kwargs):
+        """Validate the token signature."""
+        nonce = kwargs.get("nonce")
+
+        token = force_bytes(token)
+        key = self.retrieve_matching_jwk(token)
+        payload_data = self.get_payload_data(token, key)
+
+        # The 'token' will always be a byte string since it's
+        # the result of base64.urlsafe_b64decode().
+        # The payload is always the result of base64.urlsafe_b64decode().
+        # In Python 3 and 2, that's always a byte string.
+        # In Python3.6, the json.loads() function can accept a byte string
+        # as it will automagically decode it to a unicode string before
+        # deserializing https://bugs.python.org/issue17909
+        payload = json.loads(payload_data.decode("utf-8"))
+        token_nonce = payload.get("nonce")
+
+        if nonce != token_nonce:
+            msg = "JWT Nonce verification failed."
+            raise SuspiciousOperation(msg)
+        return payload
+
+    def get_token(self, payload):
+        """Return token object as a dictionary.
+        Borrowed from logindotgov-oidc, modified
+        https://github.com/trussworks/logindotgov-oidc-py
+        """
+        jwt_args = {
+            "iss": OIDC_RP_CLIENT_ID,
+            "sub": OIDC_RP_CLIENT_ID,
+            "aud": OIDC_OP_TOKEN_ENDPOINT,
+            "jti": secrets.token_hex(16),
+            "exp": int(time.time()) + 300,  # 5 minutes from now
+        }
+        # Client secret needs to be pem-encoded string
+        encoded_jwt = jwt.encode(
+            jwt_args, OIDC_RP_CLIENT_SECRET, algorithm=OIDC_RP_SIGN_ALGO
+        )
+        token_payload = {
+            "client_assertion": encoded_jwt,
+            "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+            "code": payload.get("code"),
+            "grant_type": "authorization_code",
+        }
+        response = requests.post(OIDC_OP_TOKEN_ENDPOINT, data=token_payload)
+        self.raise_token_response_error(response)
+        return response.json()
+
+    def raise_token_response_error(self, response):
+        """Raises :class:`HTTPError`, if one occurred.
+        as per: https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+        """
+        # if there wasn't an error all is good
+        if response.status_code == 200:
+            return
+        # otherwise something is up...
+        http_error_msg = (
+            f"Get Token Error (url: {response.url}, "
+            f"status: {response.status_code}, "
+            f"body: {response.text})"
+        )
+        raise HTTPError(http_error_msg, response=response)
+
+    def get_userinfo(self, access_token, id_token, payload):
+        """Return user details dictionary. The id_token and payload are not used in
+        the default implementation, but may be used when overriding this method"""
+
+        user_response = requests.get(
+            OIDC_OP_USER_ENDPOINT,
+            headers={"Authorization": "Bearer {0}".format(access_token)},
+            verify=True,
+            timeout=None,
+            proxies=None,
+        )
+        user_response.raise_for_status()
+        return user_response.json()
+
+    def authenticate(self, request, **kwargs):
+        """Authenticates a user based on the OIDC code flow."""
+
+        self.request = request
+        if not self.request:
+            return None
+
+        state = self.request.GET.get("state")
+        code = self.request.GET.get("code")
+        nonce = kwargs.pop("nonce", None)
+
+        if not code or not state:
+            return None
+
+        token_payload = {
+            "client_id": OIDC_RP_CLIENT_ID,
+            "client_secret": OIDC_RP_CLIENT_SECRET,
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": self.request.build_absolute_uri(reverse("oidc_callback")),
+        }
+
+        # Get the token
+        token_info = self.get_token(token_payload)
+        id_token = token_info.get("id_token")
+        access_token = token_info.get("access_token")
+
+        # Validate the token
+        payload = self.verify_token(id_token, nonce=nonce)
+
+        if payload:
+            try:
+                return self.get_or_create_user(access_token, id_token, payload)
+            except SuspiciousOperation as exc:
+                LOGGER.warning("failed to get or create user: %s", exc)
+                return None
+
+        return None
+
+    def get_or_create_user(self, access_token, id_token, payload):
+        """Returns a User instance if 1 user is found. Creates a user if not found
+        and configured to do so. Returns nothing if multiple users are matched."""
+
+        user_info = self.get_userinfo(access_token, id_token, payload)
+
+        claims_verified = self.verify_claims(user_info)
+        if not claims_verified:
+            msg = "Claims verification failed"
+            raise SuspiciousOperation(msg)
+
+        # unique identifier-based filtering
+        users = self.filter_users_by_claims(user_info)
+
+        if len(users) == 1:
+            return self.update_user(users[0], user_info)
+        elif len(users) > 1:
+            # In the rare case that two user accounts have the same unique identifier,
+            # bail. Randomly selecting one seems really wrong.
+            msg = "Multiple users returned"
+            raise SuspiciousOperation(msg)
+        else:
+            user = self.create_user(user_info)
+            return user
+
+    def get_user(self, user_id):
+        """Return a user based on the id."""
+
+        try:
+            return self.UserModel.objects.get(pk=user_id)
+        except self.UserModel.DoesNotExist:
+            return None

--- a/django-backend/fecfiler/authentication/test_views.py
+++ b/django-backend/fecfiler/authentication/test_views.py
@@ -1,16 +1,8 @@
-from unittest.mock import Mock
 from django.test import RequestFactory, TestCase
 from django.contrib.auth import get_user_model
 from fecfiler.authentication.views import (
     handle_invalid_login,
     handle_valid_login,
-)
-
-from .views import (
-    generate_username,
-    login_dot_gov_logout,
-    login_redirect,
-    logout_redirect,
 )
 
 UserModel = get_user_model()
@@ -23,42 +15,6 @@ class AuthenticationTest(TestCase):
     def setUp(self):
         self.user = UserModel.objects.get(id="12345678-aaaa-bbbb-cccc-111122223333")
         self.factory = RequestFactory()
-
-    def test_login_dot_gov_logout_happy_path(self):
-        test_state = "test_state"
-
-        mock_request = Mock()
-        mock_request.session = Mock()
-        mock_request.get_signed_cookie.return_value = test_state
-
-        retval = login_dot_gov_logout(mock_request)
-        self.maxDiff = None
-        self.assertEqual(
-            retval,
-            (
-                "https://idp.int.identitysandbox.gov"
-                "/openid_connect/logout?"
-                "client_id=None"
-                "&post_logout_redirect_uri=None"
-                "&state=test_state"
-            ),
-        )
-
-    def test_login_dot_gov_login_redirect(self):
-        request = self.factory.get("/")
-        request.user = self.user
-        request.session = {}
-        retval = login_redirect(request)
-        self.assertEqual(retval.status_code, 302)
-
-    def test_login_dot_gov_logout_redirect(self):
-        retval = logout_redirect(self.factory.get("/"))
-        self.assertEqual(retval.status_code, 302)
-
-    def test_generate_username(self):
-        test_uuid = "test_uuid"
-        retval = generate_username(test_uuid)
-        self.assertEqual(test_uuid, retval)
 
     def test_invalid_login(self):
         resp = handle_invalid_login("random_username")

--- a/django-backend/fecfiler/authentication/urls.py
+++ b/django-backend/fecfiler/authentication/urls.py
@@ -2,11 +2,6 @@ from django.urls import path
 from .views import (
     authenticate_login,
     authenticate_logout,
-    login_redirect,
-    logout_redirect,
-    oidc_authenticate,
-    oidc_callback,
-    oidc_logout,
 )
 
 
@@ -14,9 +9,4 @@ from .views import (
 urlpatterns = [
     path("user/login/authenticate", authenticate_login),
     path("auth/logout", authenticate_logout),
-    path("auth/login-redirect", login_redirect),
-    path("auth/logout-redirect", logout_redirect),
-    path("oidc/authenticate", oidc_authenticate),
-    path("oidc/callback", oidc_callback, name="oidc_callback"),
-    path("oidc/logout", oidc_logout),
 ]

--- a/django-backend/fecfiler/authentication/urls.py
+++ b/django-backend/fecfiler/authentication/urls.py
@@ -4,6 +4,9 @@ from .views import (
     authenticate_logout,
     login_redirect,
     logout_redirect,
+    oidc_authenticate,
+    oidc_callback,
+    oidc_logout,
 )
 
 
@@ -13,4 +16,7 @@ urlpatterns = [
     path("auth/logout", authenticate_logout),
     path("auth/login-redirect", login_redirect),
     path("auth/logout-redirect", logout_redirect),
+    path("oidc/authenticate", oidc_authenticate),
+    path("oidc/callback", oidc_callback, name="oidc_callback"),
+    path("oidc/logout", oidc_logout),
 ]

--- a/django-backend/fecfiler/authentication/utils.py
+++ b/django-backend/fecfiler/authentication/utils.py
@@ -1,0 +1,17 @@
+import logging
+
+
+from fecfiler.settings import (
+    FFAPI_LOGIN_DOT_GOV_COOKIE_NAME,
+    FFAPI_COOKIE_DOMAIN,
+    FFAPI_TIMEOUT_COOKIE_NAME,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def delete_user_logged_in_cookies(response):
+    response.delete_cookie(FFAPI_LOGIN_DOT_GOV_COOKIE_NAME, domain=FFAPI_COOKIE_DOMAIN)
+    response.delete_cookie(FFAPI_TIMEOUT_COOKIE_NAME, domain=FFAPI_COOKIE_DOMAIN)
+    response.delete_cookie("oidc_state")
+    response.delete_cookie("csrftoken", domain=FFAPI_COOKIE_DOMAIN)

--- a/django-backend/fecfiler/authentication/views.py
+++ b/django-backend/fecfiler/authentication/views.py
@@ -1,8 +1,5 @@
-from django.http import HttpResponseRedirect, HttpResponse
+from django.http import HttpResponse
 from django.contrib.auth import authenticate, logout, login
-from django.core.exceptions import SuspiciousOperation
-from django.utils.crypto import get_random_string
-from django.urls import reverse
 from django.views.decorators.http import require_http_methods
 from rest_framework.decorators import (
     authentication_classes,
@@ -10,26 +7,16 @@ from rest_framework.decorators import (
     api_view,
 )
 from fecfiler.settings import (
-    LOGIN_REDIRECT_CLIENT_URL,
-    OIDC_RP_CLIENT_ID,
-    LOGIN_REDIRECT_URL,
-    LOGOUT_REDIRECT_URL,
-    OIDC_OP_LOGOUT_ENDPOINT,
     ALTERNATIVE_LOGIN,
-    FFAPI_COOKIE_DOMAIN,
-    FFAPI_LOGIN_DOT_GOV_COOKIE_NAME,
-    FFAPI_TIMEOUT_COOKIE_NAME,
-    OIDC_ACR_VALUES,
-    OIDC_OP_AUTHORIZATION_ENDPOINT,
-    OIDC_MAX_STATES,
 )
+
+from fecfiler.authentication.utils import delete_user_logged_in_cookies
 
 from rest_framework.response import Response
 from rest_framework import status
-from urllib.parse import urlencode
 from django.http import JsonResponse
 import structlog
-import time
+
 
 logger = structlog.get_logger(__name__)
 
@@ -49,81 +36,6 @@ def handle_valid_login(user):
 def handle_invalid_login(username):
     logger.debug(f"Unauthorized login attempt: {username}")
     return HttpResponse("Unauthorized", status=401)
-
-
-def delete_user_logged_in_cookies(response):
-    response.delete_cookie(FFAPI_LOGIN_DOT_GOV_COOKIE_NAME, domain=FFAPI_COOKIE_DOMAIN)
-    response.delete_cookie(FFAPI_TIMEOUT_COOKIE_NAME, domain=FFAPI_COOKIE_DOMAIN)
-    response.delete_cookie("oidc_state")
-    response.delete_cookie("csrftoken", domain=FFAPI_COOKIE_DOMAIN)
-
-
-def handle_oidc_callback_error(request):
-    # Delete the state entry also for failed authentication attempts
-    # to prevent replay attacks.
-    if (
-        "state" in request.GET
-        and "oidc_states" in request.session
-        and request.GET["state"] in request.session["oidc_states"]
-    ):
-        del request.session["oidc_states"][request.GET["state"]]
-        request.session.save()
-
-    # Make sure the user doesn't get to continue to be logged in
-    if request.user.is_authenticated:
-        logout(request)
-    assert not request.user.is_authenticated
-    return HttpResponseRedirect("/")
-
-
-def add_nonce_to_session(request, state, nonce):
-    if "oidc_states" not in request.session or not isinstance(
-        request.session["oidc_states"], dict
-    ):
-        request.session["oidc_states"] = {}
-
-    # Make sure that the State/Nonce dictionary in the session does not get too big.
-    # If the number of State/Nonce combinations reaches a certain threshold,
-    # remove the oldest state by finding out which element has the oldest "add_on" time.
-    if len(request.session["oidc_states"]) >= OIDC_MAX_STATES:
-        logger.info(
-            'User has more than {} "oidc_states" in their session, '
-            "deleting the oldest one!".format(OIDC_MAX_STATES)
-        )
-        oldest_state = None
-        oldest_added_on = time.time()
-        for item_state, item in request.session["oidc_states"].items():
-            if item["added_on"] < oldest_added_on:
-                oldest_state = item_state
-                oldest_added_on = item["added_on"]
-        if oldest_state:
-            del request.session["oidc_states"][oldest_state]
-    request.session["oidc_states"][state] = {
-        "nonce": nonce,
-        "added_on": time.time(),
-    }
-
-
-@api_view(["GET"])
-@require_http_methods(["GET"])
-def login_redirect(request):
-    redirect = HttpResponseRedirect(LOGIN_REDIRECT_CLIENT_URL)
-    redirect.set_cookie(
-        FFAPI_LOGIN_DOT_GOV_COOKIE_NAME,
-        "true",
-        domain=FFAPI_COOKIE_DOMAIN,
-        secure=True,
-    )
-    return redirect
-
-
-@api_view(["GET"])
-@require_http_methods(["GET"])
-@permission_classes([])
-def logout_redirect(request):
-    response = HttpResponseRedirect(LOGIN_REDIRECT_CLIENT_URL)
-    delete_user_logged_in_cookies(response)
-    return response
 
 
 @api_view(["GET", "POST"])
@@ -160,83 +72,3 @@ def authenticate_logout(request):
     response = Response({}, status=status.HTTP_204_NO_CONTENT)
     delete_user_logged_in_cookies(response)
     return response
-
-
-@api_view(["GET"])
-@authentication_classes([])
-@permission_classes([])
-@require_http_methods(["GET"])
-def oidc_authenticate(request):
-    state = get_random_string(32)
-    nonce = get_random_string(32)
-    params = {
-        "acr_values": OIDC_ACR_VALUES,
-        "client_id": OIDC_RP_CLIENT_ID,
-        "prompt": "select_account",
-        "response_type": "code",
-        "redirect_uri": request.build_absolute_uri(reverse("oidc_callback")),
-        "scope": "openid email",
-        "state": state,
-        "nonce": nonce,
-    }
-    add_nonce_to_session(request, state, nonce)
-    query = urlencode(params)
-    redirect_url = "{url}?{query}".format(url=OIDC_OP_AUTHORIZATION_ENDPOINT, query=query)
-    response = HttpResponseRedirect(redirect_url)
-    response.set_signed_cookie("oidc_state", state)
-    return response
-
-
-@api_view(["GET"])
-@authentication_classes([])
-@permission_classes([])
-@require_http_methods(["GET"])
-def oidc_callback(request):
-    if (
-        "error" not in request.query_params
-        and "code" in request.query_params
-        and "state" in request.query_params
-    ):
-        state = request.query_params.get("state")
-        if (
-            "oidc_states" not in request.session
-            or state not in request.session["oidc_states"]
-        ):
-            msg = "OIDC callback state not found in session `oidc_states`!"
-            raise SuspiciousOperation(msg)
-        # Get the noncefrom the dictionary for further processing
-        # and delete the entry to prevent replay attacks.
-        nonce = request.session["oidc_states"][state]["nonce"]
-        del request.session["oidc_states"][state]
-
-        # Authenticating is slow, so save the updated oidc_states.
-        request.session.save()
-
-        kwargs = {
-            "request": request,
-            "nonce": nonce,
-        }
-
-        user = authenticate(**kwargs)
-        if user and user.is_active:
-            login(request, user)
-            return HttpResponseRedirect(LOGIN_REDIRECT_URL)
-
-    return handle_oidc_callback_error(request)
-
-
-@api_view(["GET"])
-@require_http_methods(["GET"])
-def oidc_logout(request):
-    logout_url = LOGOUT_REDIRECT_URL
-    if request.user.is_authenticated:
-        params = {
-            "client_id": OIDC_RP_CLIENT_ID,
-            "post_logout_redirect_uri": LOGOUT_REDIRECT_URL,
-            "state": request.get_signed_cookie("oidc_state"),
-        }
-        query = urlencode(params)
-        op_logout_url = OIDC_OP_LOGOUT_ENDPOINT
-        logout_url = f"{op_logout_url}?{query}"
-        logout(request)
-    return HttpResponseRedirect(logout_url)

--- a/django-backend/fecfiler/authentication/views.py
+++ b/django-backend/fecfiler/authentication/views.py
@@ -1,5 +1,8 @@
 from django.http import HttpResponseRedirect, HttpResponse
 from django.contrib.auth import authenticate, logout, login
+from django.core.exceptions import SuspiciousOperation
+from django.utils.crypto import get_random_string
+from django.urls import reverse
 from django.views.decorators.http import require_http_methods
 from rest_framework.decorators import (
     authentication_classes,
@@ -9,12 +12,17 @@ from rest_framework.decorators import (
 from fecfiler.settings import (
     LOGIN_REDIRECT_CLIENT_URL,
     OIDC_RP_CLIENT_ID,
+    LOGIN_REDIRECT_URL,
     LOGOUT_REDIRECT_URL,
     OIDC_OP_LOGOUT_ENDPOINT,
     ALTERNATIVE_LOGIN,
     FFAPI_COOKIE_DOMAIN,
     FFAPI_LOGIN_DOT_GOV_COOKIE_NAME,
     FFAPI_TIMEOUT_COOKIE_NAME,
+    OIDC_RP_CLIENT_ID,
+    OIDC_ACR_VALUES,
+    OIDC_OP_AUTHORIZATION_ENDPOINT,
+    OIDC_MAX_STATES,
 )
 
 from rest_framework.response import Response
@@ -22,6 +30,7 @@ from rest_framework import status
 from urllib.parse import urlencode
 from django.http import JsonResponse
 import structlog
+import time
 
 logger = structlog.get_logger(__name__)
 
@@ -32,27 +41,6 @@ See :py:meth:`fecfiler.authentication.views.authenticate_login`
 USERNAME_PASSWORD = "USERNAME_PASSWORD"
 
 
-def login_dot_gov_logout(request):
-    client_id = OIDC_RP_CLIENT_ID
-    post_logout_redirect_uri = LOGOUT_REDIRECT_URL
-    state = request.get_signed_cookie("oidc_state")
-
-    params = {
-        "client_id": client_id,
-        "post_logout_redirect_uri": post_logout_redirect_uri,
-        "state": state,
-    }
-    query = urlencode(params)
-    op_logout_url = OIDC_OP_LOGOUT_ENDPOINT
-    redirect_url = f"{op_logout_url}?{query}"
-
-    return redirect_url
-
-
-def generate_username(uuid):
-    return uuid
-
-
 def handle_valid_login(user):
     logger.debug(f"Successful login: {user}")
     response = HttpResponse()
@@ -61,7 +49,7 @@ def handle_valid_login(user):
 
 def handle_invalid_login(username):
     logger.debug(f"Unauthorized login attempt: {username}")
-    return HttpResponse('Unauthorized', status=401)
+    return HttpResponse("Unauthorized", status=401)
 
 
 def delete_user_logged_in_cookies(response):
@@ -69,6 +57,53 @@ def delete_user_logged_in_cookies(response):
     response.delete_cookie(FFAPI_TIMEOUT_COOKIE_NAME, domain=FFAPI_COOKIE_DOMAIN)
     response.delete_cookie("oidc_state")
     response.delete_cookie("csrftoken", domain=FFAPI_COOKIE_DOMAIN)
+
+
+def handle_oidc_callback_error(request):
+    # Delete the state entry also for failed authentication attempts
+    # to prevent replay attacks.
+    if (
+        "state" in request.GET
+        and "oidc_states" in request.session
+        and request.GET["state"] in request.session["oidc_states"]
+    ):
+        del request.session["oidc_states"][request.GET["state"]]
+        request.session.save()
+
+    # Make sure the user doesn't get to continue to be logged in
+    if request.user.is_authenticated:
+        logout(request)
+    assert not request.user.is_authenticated
+    return HttpResponseRedirect("/")
+
+
+def add_nonce_to_session(request, state, nonce):
+    if "oidc_states" not in request.session or not isinstance(
+        request.session["oidc_states"], dict
+    ):
+        request.session["oidc_states"] = {}
+
+    # Make sure that the State/Nonce dictionary in the session does not get too big.
+    # If the number of State/Nonce combinations reaches a certain threshold, remove the oldest
+    # state by finding out
+    # which element has the oldest "add_on" time.
+    if len(request.session["oidc_states"]) >= OIDC_MAX_STATES:
+        logger.info(
+            'User has more than {} "oidc_states" in their session, '
+            "deleting the oldest one!".format(OIDC_MAX_STATES)
+        )
+        oldest_state = None
+        oldest_added_on = time.time()
+        for item_state, item in request.session["oidc_states"].items():
+            if item["added_on"] < oldest_added_on:
+                oldest_state = item_state
+                oldest_added_on = item["added_on"]
+        if oldest_state:
+            del request.session["oidc_states"][oldest_state]
+    request.session["oidc_states"][state] = {
+        "nonce": nonce,
+        "added_on": time.time(),
+    }
 
 
 @api_view(["GET"])
@@ -127,3 +162,90 @@ def authenticate_logout(request):
     response = Response({}, status=status.HTTP_204_NO_CONTENT)
     delete_user_logged_in_cookies(response)
     return response
+
+
+@api_view(["GET"])
+@authentication_classes([])
+@permission_classes([])
+@require_http_methods(["GET"])
+def oidc_authenticate(request):
+    state = get_random_string(32)
+    nonce = get_random_string(32)
+    params = {
+        "acr_values": OIDC_ACR_VALUES,
+        "client_id": OIDC_RP_CLIENT_ID,
+        "prompt": "select_account",
+        "response_type": "code",
+        "redirect_uri": request.build_absolute_uri(reverse("oidc_callback")),
+        "scope": "openid email",
+        "state": state,
+        "nonce": nonce,
+    }
+    add_nonce_to_session(request, state, nonce)
+    query = urlencode(params)
+    redirect_url = "{url}?{query}".format(url=OIDC_OP_AUTHORIZATION_ENDPOINT, query=query)
+    response = HttpResponseRedirect(redirect_url)
+    response.set_signed_cookie("oidc_state", state)
+    return response
+
+
+@api_view(["GET"])
+@authentication_classes([])
+@permission_classes([])
+@require_http_methods(["GET"])
+def oidc_callback(request):
+    if (
+        "error" not in request.query_params
+        and "code" in request.query_params
+        and "state" in request.query_params
+    ):
+        state = request.query_params.get("state")
+        if (
+            "oidc_states" not in request.session
+            or state not in request.session["oidc_states"]
+        ):
+            msg = "OIDC callback state not found in session `oidc_states`!"
+            raise SuspiciousOperation(msg)
+        # Get the noncefrom the dictionary for further processing
+        # and delete the entry to prevent replay attacks.
+        nonce = request.session["oidc_states"][state]["nonce"]
+        del request.session["oidc_states"][state]
+
+        # Authenticating is slow, so save the updated oidc_states.
+        request.session.save()
+        # Reset the session. This forces the session to get reloaded from the database after
+        # fetching the token from the OpenID connect provider.
+        # Without this step we would overwrite items that are being added/removed from the
+        # session in parallel browser tabs.
+        request.session = request.session.__class__(request.session.session_key)
+
+        kwargs = {
+            "request": request,
+            "nonce": nonce,
+        }
+
+        user = authenticate(**kwargs)
+        if user and user.is_active:
+            login(request, user)
+            return HttpResponseRedirect(LOGIN_REDIRECT_URL)
+
+        return handle_oidc_callback_error(request)
+
+
+@api_view(["GET"])
+@authentication_classes([])
+@permission_classes([])
+@require_http_methods(["GET"])
+def oidc_logout(request):
+    logout_url = LOGOUT_REDIRECT_URL
+    if request.user.is_authenticated:
+        params = {
+            "client_id": OIDC_RP_CLIENT_ID,
+            "post_logout_redirect_uri": LOGOUT_REDIRECT_URL,
+            "state": request.get_signed_cookie("oidc_state"),
+        }
+        query = urlencode(params)
+        op_logout_url = OIDC_OP_LOGOUT_ENDPOINT
+        logout_url = f"{op_logout_url}?{query}"
+        logout(request)
+    return HttpResponseRedirect(logout_url)

--- a/django-backend/fecfiler/authentication/views.py
+++ b/django-backend/fecfiler/authentication/views.py
@@ -19,7 +19,6 @@ from fecfiler.settings import (
     FFAPI_COOKIE_DOMAIN,
     FFAPI_LOGIN_DOT_GOV_COOKIE_NAME,
     FFAPI_TIMEOUT_COOKIE_NAME,
-    OIDC_RP_CLIENT_ID,
     OIDC_ACR_VALUES,
     OIDC_OP_AUTHORIZATION_ENDPOINT,
     OIDC_MAX_STATES,
@@ -84,9 +83,8 @@ def add_nonce_to_session(request, state, nonce):
         request.session["oidc_states"] = {}
 
     # Make sure that the State/Nonce dictionary in the session does not get too big.
-    # If the number of State/Nonce combinations reaches a certain threshold, remove the oldest
-    # state by finding out
-    # which element has the oldest "add_on" time.
+    # If the number of State/Nonce combinations reaches a certain threshold,
+    # remove the oldest state by finding out which element has the oldest "add_on" time.
     if len(request.session["oidc_states"]) >= OIDC_MAX_STATES:
         logger.info(
             'User has more than {} "oidc_states" in their session, '
@@ -213,11 +211,6 @@ def oidc_callback(request):
 
         # Authenticating is slow, so save the updated oidc_states.
         request.session.save()
-        # Reset the session. This forces the session to get reloaded from the database after
-        # fetching the token from the OpenID connect provider.
-        # Without this step we would overwrite items that are being added/removed from the
-        # session in parallel browser tabs.
-        request.session = request.session.__class__(request.session.session_key)
 
         kwargs = {
             "request": request,
@@ -229,12 +222,10 @@ def oidc_callback(request):
             login(request, user)
             return HttpResponseRedirect(LOGIN_REDIRECT_URL)
 
-        return handle_oidc_callback_error(request)
+    return handle_oidc_callback_error(request)
 
 
 @api_view(["GET"])
-@authentication_classes([])
-@permission_classes([])
 @require_http_methods(["GET"])
 def oidc_logout(request):
     logout_url = LOGOUT_REDIRECT_URL

--- a/django-backend/fecfiler/oidc/backends.py
+++ b/django-backend/fecfiler/oidc/backends.py
@@ -41,7 +41,13 @@ class OIDCAuthenticationBackend(ModelBackend):
 
     def get_idp_unique_id_value(self, claims):
         """Helper method to clarify whether we're using OP or RP unique ID"""
-        return claims.get(settings.OIDC_OP_UNIQUE_IDENTIFIER)
+        retval = claims.get(settings.OIDC_OP_UNIQUE_IDENTIFIER)
+        if not retval:
+            msg = (
+                "Failed to retrieve OIDC_OP_UNIQUE_IDENTIFIER "
+                f"{settings.OIDC_OP_UNIQUE_IDENTIFIER} from claims"
+            )
+            raise SuspiciousOperation(msg)
 
     def filter_users_by_claims(self, claims):
         """Return all users matching the specified unique identifier."""

--- a/django-backend/fecfiler/oidc/backends.py
+++ b/django-backend/fecfiler/oidc/backends.py
@@ -1,5 +1,5 @@
 """
-This source code has been lifted from the mozilla-django-oidc
+This source code has been copied from the mozilla-django-oidc
 project:
 https://mozilla-django-oidc.readthedocs.io/en/stable/index.html#
 https://github.com/mozilla/mozilla-django-oidc/tree/main
@@ -7,7 +7,6 @@ https://github.com/mozilla/mozilla-django-oidc/tree/main
 It has been modified in places to meet the needs of the project and
 the original version can be found on Github:
 https://github.com/mozilla/mozilla-django-oidc/blob/main/mozilla_django_oidc/auth.py
-
 """
 
 import json

--- a/django-backend/fecfiler/oidc/backends.py
+++ b/django-backend/fecfiler/oidc/backends.py
@@ -48,6 +48,7 @@ class OIDCAuthenticationBackend(ModelBackend):
                 f"{settings.OIDC_OP_UNIQUE_IDENTIFIER} from claims"
             )
             raise SuspiciousOperation(msg)
+        return retval
 
     def filter_users_by_claims(self, claims):
         """Return all users matching the specified unique identifier."""

--- a/django-backend/fecfiler/oidc/test_views.py
+++ b/django-backend/fecfiler/oidc/test_views.py
@@ -1,0 +1,51 @@
+from unittest.mock import Mock
+from django.test import RequestFactory, TestCase
+from django.contrib.auth import get_user_model
+
+from .views import (
+    oidc_logout,
+    login_redirect,
+    logout_redirect,
+)
+
+UserModel = get_user_model()
+
+
+class AuthenticationTest(TestCase):
+    fixtures = ["C01234567_user_and_committee"]
+    user = None
+
+    def setUp(self):
+        self.user = UserModel.objects.get(id="12345678-aaaa-bbbb-cccc-111122223333")
+        self.factory = RequestFactory()
+
+    def test_login_dot_gov_logout_happy_path(self):
+        test_state = "test_state"
+
+        mock_request = Mock()
+        mock_request.session = Mock()
+        mock_request.get_signed_cookie.return_value = test_state
+
+        retval = oidc_logout(mock_request)
+        self.maxDiff = None
+        self.assertEqual(
+            retval,
+            (
+                "https://idp.int.identitysandbox.gov"
+                "/openid_connect/logout?"
+                "client_id=None"
+                "&post_logout_redirect_uri=None"
+                "&state=test_state"
+            ),
+        )
+
+    def test_login_dot_gov_login_redirect(self):
+        request = self.factory.get("/")
+        request.user = self.user
+        request.session = {}
+        retval = login_redirect(request)
+        self.assertEqual(retval.status_code, 302)
+
+    def test_login_dot_gov_logout_redirect(self):
+        retval = logout_redirect(self.factory.get("/"))
+        self.assertEqual(retval.status_code, 302)

--- a/django-backend/fecfiler/oidc/tests/test_backends.py
+++ b/django-backend/fecfiler/oidc/tests/test_backends.py
@@ -1,0 +1,188 @@
+"""
+This source code has been copied from the mozilla-django-oidc
+project:
+https://mozilla-django-oidc.readthedocs.io/en/stable/index.html#
+https://github.com/mozilla/mozilla-django-oidc/tree/main
+
+It has been modified in places to meet the needs of the project and
+the original version can be found on Github:
+https://github.com/mozilla/mozilla-django-oidc/blob/main/tests/test_auth.py
+"""
+
+import json
+from jwcrypto import jwk
+from jwcrypto.common import json_decode
+from unittest.mock import Mock, patch
+from requests.exceptions import HTTPError
+from django.core.exceptions import SuspiciousOperation
+
+
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, TestCase, override_settings
+from django.utils.encoding import force_bytes, smart_str
+from josepy.b64 import b64encode
+
+from fecfiler.oidc.backends import OIDCAuthenticationBackend
+
+User = get_user_model()
+
+
+@override_settings(OIDC_OP_TOKEN_ENDPOINT="https://server.example.com/token")
+@override_settings(OIDC_OP_USER_ENDPOINT="https://server.example.com/user")
+@override_settings(OIDC_RP_CLIENT_ID="example_id")
+@override_settings(OIDC_RP_CLIENT_SECRET="client_secret")
+class OIDCAuthenticationBackendTestCase(TestCase):
+    def setUp(self):
+        self.backend = OIDCAuthenticationBackend()
+
+    @patch("fecfiler.oidc.backends.requests")
+    @patch("fecfiler.oidc.backends.jwt")
+    def test_authenticate_bad_token_response(
+        self,
+        jwt_mock,
+        requests_mock,
+    ):
+        post_json_mock = Mock(status_code=500)
+        requests_mock.post.return_value = post_json_mock
+
+        auth_request = RequestFactory().get("/foo", {"code": "foo", "state": "bar"})
+        with self.assertRaises(HTTPError):
+            self.backend.authenticate(request=auth_request)
+
+    @patch("fecfiler.oidc.backends.requests")
+    @patch("fecfiler.oidc.backends.jwt")
+    @patch("fecfiler.oidc.backends.JWS")
+    def test_authenticate_invalid_jwks(
+        self,
+        jws_mock,
+        jwt_mock,
+        requests_mock,
+    ):
+        test_jws_json_header = '{"kid":"test_kid","alg":"RS256"}'
+
+        post_json_mock = Mock(status_code=200)
+        post_json_mock.json.return_value = {
+            "id_token": "id_token",
+            "access_token": "access_granted",
+        }
+        requests_mock.post.return_value = post_json_mock
+        jws_mock.from_compact.return_value.signature.protected = test_jws_json_header
+
+        auth_request = RequestFactory().get("/foo", {"code": "foo", "state": "bar"})
+        with self.assertRaisesMessage(
+            SuspiciousOperation, "Could not find a valid JWKS."
+        ):
+            self.backend.authenticate(request=auth_request)
+
+    @patch("fecfiler.oidc.backends.requests")
+    @patch("fecfiler.oidc.backends.jwt")
+    @patch("fecfiler.oidc.backends.JWS")
+    def test_authenticate_verify_jws_failed_no_alg(
+        self,
+        jws_mock,
+        jwt_mock,
+        requests_mock,
+    ):
+        test_jws_json_header = '{"kid":"test_kid","alg":"RS256"}'
+        test_jwks = {"keys": [{"alg": "RS256", "kid": "test_kid"}]}
+
+        post_json_mock = Mock(status_code=200)
+        post_json_mock.json.return_value = {
+            "id_token": "id_token",
+            "access_token": "access_granted",
+        }
+
+        get_json_mock = Mock(status_code=200)
+        get_json_mock.json.return_value = test_jwks
+
+        requests_mock.post.return_value = post_json_mock
+        requests_mock.get.return_value = get_json_mock
+        jws_mock.from_compact.return_value.signature.protected = test_jws_json_header
+        jws_mock.from_compact.return_value.signature.combined = {}
+
+        auth_request = RequestFactory().get("/foo", {"code": "foo", "state": "bar"})
+        with self.assertRaisesMessage(
+            SuspiciousOperation, "No alg value found in header"
+        ):
+            self.backend.authenticate(request=auth_request)
+
+    @patch("fecfiler.oidc.backends.requests")
+    @patch("fecfiler.oidc.backends.jwt")
+    @patch("fecfiler.oidc.backends.JWS")
+    def test_authenticate_verify_jws_failed_alg_does_not_match(
+        self,
+        jws_mock,
+        jwt_mock,
+        requests_mock,
+    ):
+        test_jws_json_header = '{"kid":"test_kid","alg":"RS256"}'
+        test_jwks = {"keys": [{"alg": "RS256", "kid": "test_kid"}]}
+        test_alg = "invalid_alg_name"
+
+        post_json_mock = Mock(status_code=200)
+        post_json_mock.json.return_value = {
+            "id_token": "id_token",
+            "access_token": "access_granted",
+        }
+
+        get_json_mock = Mock(status_code=200)
+        get_json_mock.json.return_value = test_jwks
+
+        requests_mock.post.return_value = post_json_mock
+        requests_mock.get.return_value = get_json_mock
+        jws_mock.from_compact.return_value.signature.protected = test_jws_json_header
+        jws_mock.from_compact.return_value.signature.combined.alg.name = test_alg
+
+        auth_request = RequestFactory().get("/foo", {"code": "foo", "state": "bar"})
+        with self.assertRaisesMessage(
+            SuspiciousOperation,
+            "The provider algorithm {!r} does not match the client's "
+            "OIDC_RP_SIGN_ALGO.".format("invalid_alg_name"),
+        ):
+            self.backend.authenticate(request=auth_request)
+
+    @patch("fecfiler.oidc.backends.requests")
+    @patch("fecfiler.oidc.backends.jwt")
+    @patch("fecfiler.oidc.backends.JWS")
+    def test_authenticate_verify_jws_lib_call_failed(
+        self,
+        jws_mock,
+        jwt_mock,
+        requests_mock,
+    ):
+        test_jws_json_header = '{"kid":"test_kid","alg":"RS256"}'
+        test_jwks = {
+            "keys": [
+                {
+                    "alg": "RS256",
+                    "use": "sig",
+                    "kty": "RSA",
+                    "n": "test_n",
+                    "e": "test_e",
+                    "kid": "test_kid",
+                }
+            ]
+        }
+        test_alg = "RS256"
+
+        post_json_mock = Mock(status_code=200)
+        post_json_mock.json.return_value = {
+            "id_token": "id_token",
+            "access_token": "access_granted",
+        }
+
+        get_json_mock = Mock(status_code=200)
+        get_json_mock.json.return_value = test_jwks
+
+        requests_mock.post.return_value = post_json_mock
+        requests_mock.get.return_value = get_json_mock
+        jws_mock.from_compact.return_value.signature.protected = test_jws_json_header
+        jws_mock.from_compact.return_value.signature.combined.alg.name = test_alg
+        jws_mock.from_compact.return_value.verify.return_value = False
+
+        auth_request = RequestFactory().get("/foo", {"code": "foo", "state": "bar"})
+        with self.assertRaisesMessage(
+            SuspiciousOperation,
+            "JWS token verification failed",
+        ):
+            self.backend.authenticate(request=auth_request)

--- a/django-backend/fecfiler/oidc/tests/test_backends.py
+++ b/django-backend/fecfiler/oidc/tests/test_backends.py
@@ -12,11 +12,8 @@ https://github.com/mozilla/mozilla-django-oidc/blob/main/tests/test_auth.py
 from unittest.mock import Mock, patch
 from requests.exceptions import HTTPError
 from django.core.exceptions import SuspiciousOperation
-from django.contrib.auth import get_user_model
 from django.test import RequestFactory, TestCase, override_settings
 from fecfiler.oidc.backends import OIDCAuthenticationBackend
-
-User = get_user_model()
 
 
 @override_settings(OIDC_OP_TOKEN_ENDPOINT="https://server.example.com/token")
@@ -329,8 +326,6 @@ class OIDCAuthenticationBackendTestCase(TestCase):
             SuspiciousOperation,
             "Multiple users returned",
         ):
-
-            self.backend.UserModel.objects = Mock()
             self.backend.authenticate(request=auth_request, nonce="test_nonce_value")
 
     @patch("fecfiler.oidc.backends.requests")
@@ -382,6 +377,6 @@ class OIDCAuthenticationBackendTestCase(TestCase):
 
         auth_request = RequestFactory().get("/foo", {"code": "foo", "state": "bar"})
 
-        self.backend.UserModel.objects = Mock()
+        self.backend.UserModel.objects.create_user = Mock()
         retval = self.backend.authenticate(request=auth_request, nonce="test_nonce_value")
         self.assertIsNotNone(retval)

--- a/django-backend/fecfiler/oidc/tests/test_views.py
+++ b/django-backend/fecfiler/oidc/tests/test_views.py
@@ -5,7 +5,6 @@ from django.contrib.sessions.middleware import SessionMiddleware
 from unittest.mock import MagicMock
 
 from fecfiler.oidc.views import (
-    oidc_logout,
     login_redirect,
     logout_redirect,
     oidc_authenticate,

--- a/django-backend/fecfiler/oidc/tests/test_views.py
+++ b/django-backend/fecfiler/oidc/tests/test_views.py
@@ -1,22 +1,42 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from django.test import RequestFactory, TestCase
 from django.contrib.auth import get_user_model
+from django.contrib.sessions.middleware import SessionMiddleware
+from unittest.mock import MagicMock
 
 from fecfiler.oidc.views import (
     oidc_logout,
     login_redirect,
     logout_redirect,
+    oidc_authenticate,
+    oidc_callback,
+    oidc_logout,
 )
+
+
+import time
 
 UserModel = get_user_model()
 
 
+class MockUser:
+    is_authenticated = True
+    is_active = True
+
+
 class OidcTest(TestCase):
     fixtures = ["C01234567_user_and_committee"]
-    user = None
+    user = MockUser()
+
+    def get_request(self, uri):
+        request = self.factory.get(uri)
+        request.user = self.user
+        self.middleware = SessionMiddleware(MagicMock())
+        self.middleware.process_request(request)
+        request.session.save()
+        return request
 
     def setUp(self):
-        self.user = UserModel.objects.get(id="12345678-aaaa-bbbb-cccc-111122223333")
         self.factory = RequestFactory()
 
     def xtest_login_dot_gov_logout_happy_path(self):
@@ -39,13 +59,81 @@ class OidcTest(TestCase):
             ),
         )
 
-    def test_login_dot_gov_login_redirect(self):
+    def test_login_redirect(self):
         request = self.factory.get("/")
         request.user = self.user
         request.session = {}
         retval = login_redirect(request)
         self.assertEqual(retval.status_code, 302)
 
-    def test_login_dot_gov_logout_redirect(self):
+    def test_logout_redirect(self):
         retval = logout_redirect(self.factory.get("/"))
+        self.assertEqual(retval.status_code, 302)
+
+    def test_oidc_authenticate(self):
+        request = self.factory.get("/")
+        request.user = self.user
+        request.session = {
+            "oidc_states": {
+                "test_state_1_key": {"nonce": "test_nonce_1", "added_on": time.time()},
+                "test_state_2_key": {"nonce": "test_nonce_2", "added_on": time.time()},
+                "test_state_3_key": {"nonce": "test_nonce_3", "added_on": time.time()},
+            }
+        }
+        retval = oidc_authenticate(request)
+        self.assertEqual(retval.status_code, 302)
+        self.assertIsNotNone(retval.cookies.get("oidc_state"))
+
+    def test_oidc_callback_error(self):
+        test_state = "test_state"
+        request = self.get_request(f"/?error=true&state={test_state}")
+        request.session["oidc_states"] = {
+            test_state: {"nonce": "test_nonce_1", "added_on": time.time()},
+        }
+        request.user = self.user
+
+        retval = oidc_callback(request)
+        self.assertEqual(retval.status_code, 302)
+        self.assertEqual(len(request.session.get("oidc_states")), 0)
+
+    def test_oidc_callback_session_states_not_found(self):
+        test_code = "test_code"
+        test_state = "test_state"
+        request = self.get_request(f"/?code={test_code}&state={test_state}")
+
+        retval = oidc_callback(request)
+        self.assertEqual(retval.status_code, 500)
+
+    @patch("fecfiler.oidc.utils.authenticate")
+    @patch("fecfiler.oidc.utils.login")
+    def test_oidc_callback_happy_path(self, login_mock, authenticate_mock):
+        test_code = "test_code"
+        test_state = "test_state"
+
+        authenticate_mock.return_value = self.user
+
+        request = self.get_request(f"/?code={test_code}&state={test_state}")
+        request.session["oidc_states"] = {
+            test_state: {"nonce": "test_nonce_1", "added_on": time.time()},
+        }
+
+        retval = oidc_callback(request)
+        self.assertEqual(retval.status_code, 302)
+
+    def test_oidc_logout_happy_path(self):
+        auth_request = self.factory.get("/")
+        auth_request.user = self.user
+        auth_request.session = {
+            "oidc_states": {
+                "test_state_1_key": {"nonce": "test_nonce_1", "added_on": time.time()},
+                "test_state_2_key": {"nonce": "test_nonce_2", "added_on": time.time()},
+                "test_state_3_key": {"nonce": "test_nonce_3", "added_on": time.time()},
+            }
+        }
+        auth_response = oidc_authenticate(auth_request)
+
+        request = self.get_request("/")
+        request.COOKIES["oidc_state"] = auth_response.cookies["oidc_state"].value
+
+        retval = oidc_logout(request)
         self.assertEqual(retval.status_code, 302)

--- a/django-backend/fecfiler/oidc/tests/test_views.py
+++ b/django-backend/fecfiler/oidc/tests/test_views.py
@@ -2,7 +2,7 @@ from unittest.mock import Mock
 from django.test import RequestFactory, TestCase
 from django.contrib.auth import get_user_model
 
-from .views import (
+from fecfiler.oidc.views import (
     oidc_logout,
     login_redirect,
     logout_redirect,
@@ -11,7 +11,7 @@ from .views import (
 UserModel = get_user_model()
 
 
-class AuthenticationTest(TestCase):
+class OidcTest(TestCase):
     fixtures = ["C01234567_user_and_committee"]
     user = None
 
@@ -19,7 +19,7 @@ class AuthenticationTest(TestCase):
         self.user = UserModel.objects.get(id="12345678-aaaa-bbbb-cccc-111122223333")
         self.factory = RequestFactory()
 
-    def test_login_dot_gov_logout_happy_path(self):
+    def xtest_login_dot_gov_logout_happy_path(self):
         test_state = "test_state"
 
         mock_request = Mock()

--- a/django-backend/fecfiler/oidc/urls.py
+++ b/django-backend/fecfiler/oidc/urls.py
@@ -1,0 +1,18 @@
+from django.urls import path
+from .views import (
+    login_redirect,
+    logout_redirect,
+    oidc_authenticate,
+    oidc_callback,
+    oidc_logout,
+)
+
+
+# The API URLs are now determined automatically by the router.
+urlpatterns = [
+    path("oidc/login-redirect", login_redirect),
+    path("oidc/logout-redirect", logout_redirect),
+    path("oidc/authenticate", oidc_authenticate),
+    path("oidc/callback", oidc_callback, name="oidc_callback"),
+    path("oidc/logout", oidc_logout),
+]

--- a/django-backend/fecfiler/oidc/utils.py
+++ b/django-backend/fecfiler/oidc/utils.py
@@ -1,0 +1,99 @@
+"""
+This source code has been copied from the mozilla-django-oidc
+project:
+https://mozilla-django-oidc.readthedocs.io/en/stable/index.html#
+https://github.com/mozilla/mozilla-django-oidc/tree/main
+
+It has been modified in places to meet the needs of the project and
+the original version can be found on Github:
+https://github.com/mozilla/mozilla-django-oidc/blob/main/mozilla_django_oidc/utils.py
+https://github.com/mozilla/mozilla-django-oidc/blob/main/mozilla_django_oidc/views.py
+"""
+
+import logging
+
+import time
+
+from django.core.exceptions import SuspiciousOperation
+from django.contrib.auth import logout, authenticate, login
+from django.http import HttpResponseRedirect
+
+from fecfiler.settings import (
+    OIDC_MAX_STATES,
+    LOGIN_REDIRECT_URL,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def handle_oidc_callback_request(request):
+    state = request.query_params.get("state")
+    if (
+        "oidc_states" not in request.session
+        or state not in request.session["oidc_states"]
+    ):
+        msg = "OIDC callback state not found in session `oidc_states`!"
+        raise SuspiciousOperation(msg)
+    # Get the noncefrom the dictionary for further processing
+    # and delete the entry to prevent replay attacks.
+    nonce = request.session["oidc_states"][state]["nonce"]
+    del request.session["oidc_states"][state]
+
+    # Authenticating is slow, so save the updated oidc_states.
+    request.session.save()
+
+    kwargs = {
+        "request": request,
+        "nonce": nonce,
+    }
+
+    user = authenticate(**kwargs)
+    if user and user.is_active:
+        login(request, user)
+        return HttpResponseRedirect(LOGIN_REDIRECT_URL)
+
+
+def handle_oidc_callback_error(request):
+    # Delete the state entry also for failed authentication attempts
+    # to prevent replay attacks.
+    if (
+        "state" in request.GET
+        and "oidc_states" in request.session
+        and request.GET["state"] in request.session["oidc_states"]
+    ):
+        del request.session["oidc_states"][request.GET["state"]]
+        request.session.save()
+
+    # Make sure the user doesn't get to continue to be logged in
+    if request.user.is_authenticated:
+        logout(request)
+    assert not request.user.is_authenticated
+    return HttpResponseRedirect("/")
+
+
+def add_oidc_nonce_to_session(request, state, nonce):
+    if "oidc_states" not in request.session or not isinstance(
+        request.session["oidc_states"], dict
+    ):
+        request.session["oidc_states"] = {}
+
+    # Make sure that the State/Nonce dictionary in the session does not get too big.
+    # If the number of State/Nonce combinations reaches a certain threshold,
+    # remove the oldest state by finding out which element has the oldest "add_on" time.
+    if len(request.session["oidc_states"]) >= OIDC_MAX_STATES:
+        LOGGER.info(
+            'User has more than {} "oidc_states" in their session, '
+            "deleting the oldest one!".format(OIDC_MAX_STATES)
+        )
+        oldest_state = None
+        oldest_added_on = time.time()
+        for item_state, item in request.session["oidc_states"].items():
+            if item["added_on"] < oldest_added_on:
+                oldest_state = item_state
+                oldest_added_on = item["added_on"]
+        if oldest_state:
+            del request.session["oidc_states"][oldest_state]
+    request.session["oidc_states"][state] = {
+        "nonce": nonce,
+        "added_on": time.time(),
+    }

--- a/django-backend/fecfiler/oidc/utils.py
+++ b/django-backend/fecfiler/oidc/utils.py
@@ -16,11 +16,10 @@ import time
 
 from django.core.exceptions import SuspiciousOperation
 from django.contrib.auth import logout, authenticate, login
-from django.http import HttpResponseRedirect
+
 
 from fecfiler.settings import (
     OIDC_MAX_STATES,
-    LOGIN_REDIRECT_URL,
 )
 
 LOGGER = logging.getLogger(__name__)
@@ -50,7 +49,6 @@ def handle_oidc_callback_request(request):
     user = authenticate(**kwargs)
     if user and user.is_active:
         login(request, user)
-        return HttpResponseRedirect(LOGIN_REDIRECT_URL)
 
 
 def handle_oidc_callback_error(request):
@@ -68,7 +66,6 @@ def handle_oidc_callback_error(request):
     if request.user.is_authenticated:
         logout(request)
     assert not request.user.is_authenticated
-    return HttpResponseRedirect("/")
 
 
 def add_oidc_nonce_to_session(request, state, nonce):

--- a/django-backend/fecfiler/oidc/views.py
+++ b/django-backend/fecfiler/oidc/views.py
@@ -1,0 +1,120 @@
+"""
+This source code has been copied from the mozilla-django-oidc
+project:
+https://mozilla-django-oidc.readthedocs.io/en/stable/index.html#
+https://github.com/mozilla/mozilla-django-oidc/tree/main
+
+It has been modified in places to meet the needs of the project and
+the original version can be found on Github:
+https://github.com/mozilla/mozilla-django-oidc/blob/main/mozilla_django_oidc/views.py
+"""
+
+from django.http import HttpResponseRedirect
+from django.contrib.auth import logout
+from django.utils.crypto import get_random_string
+from django.urls import reverse
+from django.views.decorators.http import require_http_methods
+from rest_framework.decorators import (
+    authentication_classes,
+    permission_classes,
+    api_view,
+)
+from fecfiler.settings import (
+    LOGIN_REDIRECT_CLIENT_URL,
+    OIDC_RP_CLIENT_ID,
+    LOGOUT_REDIRECT_URL,
+    OIDC_OP_LOGOUT_ENDPOINT,
+    FFAPI_COOKIE_DOMAIN,
+    FFAPI_LOGIN_DOT_GOV_COOKIE_NAME,
+    OIDC_ACR_VALUES,
+    OIDC_OP_AUTHORIZATION_ENDPOINT,
+)
+from fecfiler.authentication.utils import delete_user_logged_in_cookies
+
+from .utils import (
+    add_oidc_nonce_to_session,
+    handle_oidc_callback_error,
+    handle_oidc_callback_request,
+)
+
+from urllib.parse import urlencode
+import structlog
+
+logger = structlog.get_logger(__name__)
+
+
+@api_view(["GET"])
+@require_http_methods(["GET"])
+def login_redirect(request):
+    redirect = HttpResponseRedirect(LOGIN_REDIRECT_CLIENT_URL)
+    redirect.set_cookie(
+        FFAPI_LOGIN_DOT_GOV_COOKIE_NAME,
+        "true",
+        domain=FFAPI_COOKIE_DOMAIN,
+        secure=True,
+    )
+    return redirect
+
+
+@api_view(["GET"])
+@require_http_methods(["GET"])
+@permission_classes([])
+def logout_redirect(request):
+    response = HttpResponseRedirect(LOGIN_REDIRECT_CLIENT_URL)
+    delete_user_logged_in_cookies(response)
+    return response
+
+
+@api_view(["GET"])
+@authentication_classes([])
+@permission_classes([])
+@require_http_methods(["GET"])
+def oidc_authenticate(request):
+    state = get_random_string(32)
+    nonce = get_random_string(32)
+    params = {
+        "acr_values": OIDC_ACR_VALUES,
+        "client_id": OIDC_RP_CLIENT_ID,
+        "prompt": "select_account",
+        "response_type": "code",
+        "redirect_uri": request.build_absolute_uri(reverse("oidc_callback")),
+        "scope": "openid email",
+        "state": state,
+        "nonce": nonce,
+    }
+    add_oidc_nonce_to_session(request, state, nonce)
+    query = urlencode(params)
+    redirect_url = "{url}?{query}".format(url=OIDC_OP_AUTHORIZATION_ENDPOINT, query=query)
+    response = HttpResponseRedirect(redirect_url)
+    response.set_signed_cookie("oidc_state", state)
+    return response
+
+
+@api_view(["GET"])
+@authentication_classes([])
+@permission_classes([])
+@require_http_methods(["GET"])
+def oidc_callback(request):
+    if (
+        "error" not in request.query_params
+        and "code" in request.query_params
+        and "state" in request.query_params
+    ):
+        return handle_oidc_callback_request(request)
+    return handle_oidc_callback_error(request)
+
+
+@api_view(["GET"])
+@require_http_methods(["GET"])
+def oidc_logout(request):
+    if request.user.is_authenticated:
+        params = {
+            "client_id": OIDC_RP_CLIENT_ID,
+            "post_logout_redirect_uri": LOGOUT_REDIRECT_URL,
+            "state": request.get_signed_cookie("oidc_state"),
+        }
+        query = urlencode(params)
+        op_logout_url = OIDC_OP_LOGOUT_ENDPOINT
+        logout_url = f"{op_logout_url}?{query}"
+        logout(request)
+    return HttpResponseRedirect(logout_url or LOGOUT_REDIRECT_URL)

--- a/django-backend/fecfiler/oidc/views.py
+++ b/django-backend/fecfiler/oidc/views.py
@@ -86,7 +86,7 @@ def oidc_authenticate(request):
     query = urlencode(params)
     redirect_url = "{url}?{query}".format(url=OIDC_OP_AUTHORIZATION_ENDPOINT, query=query)
     response = HttpResponseRedirect(redirect_url)
-    response.set_signed_cookie("oidc_state", state)
+    response.set_signed_cookie("oidc_state", state, secure=True, httponly=True)
     return response
 
 

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -56,7 +56,6 @@ SESSION_SAVE_EVERY_REQUEST = True
 INSTALLED_APPS = [
     # "django.contrib.admin",
     "django.contrib.auth",
-    "mozilla_django_oidc",  # Load after auth
     "django.contrib.contenttypes",
     "django.contrib.sessions",
     "django.contrib.messages",
@@ -140,11 +139,9 @@ FECFILE_GITHUB_TOKEN = env.get_credential("FECFILE_GITHUB_TOKEN")
 # OpenID Connect settings start
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
-    "mozilla_django_oidc.auth.OIDCAuthenticationBackend",
+    "fecfiler.authentication.backends.OIDCAuthenticationBackend",
 ]
 
-OIDC_CREATE_USER = True
-OIDC_STORE_ID_TOKEN = True
 # Maximum number of concurrent sessions
 OIDC_MAX_STATES = 3
 
@@ -158,9 +155,6 @@ OIDC_RP_UNIQUE_IDENTIFIER = "username"
 # Sometimes the OP (IDP - login.gov)has a different label for the unique ID
 OIDC_OP_UNIQUE_IDENTIFIER = "sub"
 
-# Default implicit_flow is considered vulnerable
-OIDC_OP_CLIENT_AUTH_METHOD = "private_key_jwt"
-
 OIDC_OP_AUTODISCOVER_ENDPOINT = (
     "https://idp.int.identitysandbox.gov/.well-known/openid-configuration"
 )
@@ -171,7 +165,6 @@ OIDC_OP_AUTHORIZATION_ENDPOINT = OIDC_OP_CONFIG.get("authorization_endpoint")
 OIDC_OP_TOKEN_ENDPOINT = OIDC_OP_CONFIG.get("token_endpoint")
 OIDC_OP_USER_ENDPOINT = OIDC_OP_CONFIG.get("userinfo_endpoint")
 OIDC_OP_LOGOUT_ENDPOINT = OIDC_OP_CONFIG.get("end_session_endpoint")
-ALLOW_LOGOUT_GET_METHOD = True
 
 FFAPI_COOKIE_DOMAIN = env.get_credential("FFAPI_COOKIE_DOMAIN")
 FFAPI_LOGIN_DOT_GOV_COOKIE_NAME = "ffapi_login_dot_gov"
@@ -181,13 +174,7 @@ LOGIN_REDIRECT_URL = env.get_credential("LOGIN_REDIRECT_SERVER_URL")
 LOGIN_REDIRECT_CLIENT_URL = env.get_credential("LOGIN_REDIRECT_CLIENT_URL")
 LOGOUT_REDIRECT_URL = env.get_credential("LOGOUT_REDIRECT_URL")
 
-OIDC_AUTH_REQUEST_EXTRA_PARAMS = {
-    "acr_values": "http://idmanagement.gov/ns/assurance/ial/1"
-}
-
-OIDC_OP_LOGOUT_URL_METHOD = "fecfiler.authentication.views.login_dot_gov_logout"
-
-OIDC_USERNAME_ALGO = "fecfiler.authentication.views.generate_username"
+OIDC_ACR_VALUES = "http://idmanagement.gov/ns/assurance/ial/1"
 # OpenID Connect settings end
 
 USE_X_FORWARDED_HOST = True

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -76,6 +76,7 @@ INSTALLED_APPS = [
     "fecfiler.openfec",
     "fecfiler.user",
     "fecfiler.mock_openfec",
+    "fecfiler.oidc",
 ]
 
 MIDDLEWARE = [
@@ -139,7 +140,7 @@ FECFILE_GITHUB_TOKEN = env.get_credential("FECFILE_GITHUB_TOKEN")
 # OpenID Connect settings start
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
-    "fecfiler.authentication.backends.OIDCAuthenticationBackend",
+    "fecfiler.oidc.backends.OIDCAuthenticationBackend",
 ]
 
 # Maximum number of concurrent sessions

--- a/django-backend/fecfiler/urls.py
+++ b/django-backend/fecfiler/urls.py
@@ -33,6 +33,7 @@ urlpatterns = [
     re_path(BASE_V1_URL, include("fecfiler.openfec.urls")),
     re_path(BASE_V1_URL, include("fecfiler.user.urls")),
     re_path(BASE_V1_URL, include("fecfiler.feedback.urls")),
+    re_path(BASE_V1_URL, include("fecfiler.oidc.urls")),
     re_path(r"^celery-test/", test_celery),
     path("", RedirectView.as_view(url=LOGIN_REDIRECT_CLIENT_URL)),
     re_path(BASE_V1_URL + "status/", get_api_status),

--- a/django-backend/fecfiler/urls.py
+++ b/django-backend/fecfiler/urls.py
@@ -33,8 +33,7 @@ urlpatterns = [
     re_path(BASE_V1_URL, include("fecfiler.openfec.urls")),
     re_path(BASE_V1_URL, include("fecfiler.user.urls")),
     re_path(BASE_V1_URL, include("fecfiler.feedback.urls")),
-    re_path(r"^oidc/", include("mozilla_django_oidc.urls")),
     re_path(r"^celery-test/", test_celery),
     path("", RedirectView.as_view(url=LOGIN_REDIRECT_CLIENT_URL)),
-    re_path(BASE_V1_URL + "status/", get_api_status)
+    re_path(BASE_V1_URL + "status/", get_api_status),
 ]

--- a/django-backend/fecfiler/utils.py
+++ b/django-backend/fecfiler/utils.py
@@ -1,6 +1,6 @@
 from rest_framework.exceptions import ValidationError
 from django.http import HttpResponseServerError
-from fecfiler.authentication.views import delete_user_logged_in_cookies
+from fecfiler.authentication.utils import delete_user_logged_in_cookies
 from rest_framework.views import exception_handler
 import structlog
 

--- a/manifests/manifest-dev-api.yml
+++ b/manifests/manifest-dev-api.yml
@@ -19,8 +19,8 @@ applications:
       DJANGO_SETTINGS_MODULE: fecfiler.settings.production
       FFAPI_COOKIE_DOMAIN: fecfile.fec.gov
       LOGIN_REDIRECT_CLIENT_URL: https://dev.fecfile.fec.gov
-      LOGIN_REDIRECT_SERVER_URL: https://dev-api.fecfile.fec.gov/api/v1/auth/login-redirect
-      LOGOUT_REDIRECT_URL: https://dev-api.fecfile.fec.gov/api/v1/auth/logout-redirect
+      LOGIN_REDIRECT_SERVER_URL: https://dev-api.fecfile.fec.gov/api/v1/oidc/login-redirect
+      LOGOUT_REDIRECT_URL: https://dev-api.fecfile.fec.gov/api/v1/oidc/logout-redirect
       FEC_API: https://api.open.fec.gov/v1/
       SESSION_COOKIE_AGE: 64800
       BP_PIP_VERSION: latest

--- a/manifests/manifest-prod-api.yml
+++ b/manifests/manifest-prod-api.yml
@@ -19,8 +19,8 @@ applications:
       DJANGO_SETTINGS_MODULE: fecfiler.settings.production
       FFAPI_COOKIE_DOMAIN: fecfile.fec.gov
       LOGIN_REDIRECT_CLIENT_URL: https://fecfile.fec.gov
-      LOGIN_REDIRECT_SERVER_URL: https://api.fecfile.fec.gov/api/v1/auth/login-redirect
-      LOGOUT_REDIRECT_URL: https://api.fecfile.fec.gov/api/v1/auth/logout-redirect
+      LOGIN_REDIRECT_SERVER_URL: https://api.fecfile.fec.gov/api/v1/oidc/login-redirect
+      LOGOUT_REDIRECT_URL: https://api.fecfile.fec.gov/api/v1/oidc/logout-redirect
       FEC_API: https://api.open.fec.gov/v1/
       SESSION_COOKIE_AGE: 64800
       BP_PIP_VERSION: latest

--- a/manifests/manifest-stage-api.yml
+++ b/manifests/manifest-stage-api.yml
@@ -19,8 +19,8 @@ applications:
       DJANGO_SETTINGS_MODULE: fecfiler.settings.production
       FFAPI_COOKIE_DOMAIN: fecfile.fec.gov
       LOGIN_REDIRECT_CLIENT_URL: https://stage.fecfile.fec.gov
-      LOGIN_REDIRECT_SERVER_URL: https://stage-api.fecfile.fec.gov/api/v1/auth/login-redirect
-      LOGOUT_REDIRECT_URL: https://stage-api.fecfile.fec.gov/api/v1/auth/logout-redirect
+      LOGIN_REDIRECT_SERVER_URL: https://stage-api.fecfile.fec.gov/api/v1/oidc/login-redirect
+      LOGOUT_REDIRECT_URL: https://stage-api.fecfile.fec.gov/api/v1/oidc/logout-redirect
       FEC_API: https://api.open.fec.gov/v1/
       SESSION_COOKIE_AGE: 64800
       BP_PIP_VERSION: latest

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ coreschema==0.0.4
 decorator==5.1.1
 dj-database-url==1.3.0
 dj-static==0.0.6
-Django==4.2.11  # when updating this, also update requirements/tox versions in fecgov/mozilla_django_oidc
+Django==4.2.11
 django-cors-headers==4.3.1
 django-storages==1.13.1
 djangorestframework==3.14.0
@@ -23,10 +23,10 @@ pytz==2022.6
 retry==0.9.2
 static3==0.7.0
 django-otp==1.1.4
-git+https://github.com/fecgov/mozilla-django-oidc.git@5a813c15fba5463a2907b2e22af6089f349c63e7#egg=mozilla_django_oidc
 zeep==4.2.1
 django-structlog[celery]==7.1.0
 rich==13.7.0
+josepy==1.14.0
 
 # Pinning sqlparse to 0.5.0 as it is a sub-dependency that needs to be upgraded for security
 sqlparse==0.5.0


### PR DESCRIPTION
https://github.com/fecgov/fecfile-web-api/issues/892

This ticket does the following:

1. removes mozilla-django-oidc dependency
2. creates a new oidc fecfiler app to handle oidc auth and updated urls to use this
3. pulled only necessary logic from mozilla-django-oidc into oidc/ code.  A good amount of it was refactored or cleaned up but attribution was still given
4. any oidc supporting logic was moved from authentication/ to oidc/
5. test coverage to oidc/ was added
6. settings were cleaned up to remove those no longer needed without the mozilla package