### PR TITLE
Feature/1481 Update dependent child and grandchild transaction descriptions on save

### DIFF
--- a/django-backend/fecfiler/transactions/tests/test_transaction_dependencies.py
+++ b/django-backend/fecfiler/transactions/tests/test_transaction_dependencies.py
@@ -1,0 +1,87 @@
+from django.test import TestCase
+from fecfiler.committee_accounts.models import CommitteeAccount
+from fecfiler.contacts.models import Contact
+from fecfiler.transactions.transaction_dependencies import (
+    get_jf_transfer_description,
+    update_dependent_descriptions,
+)
+from fecfiler.transactions.tests.utils import create_schedule_a
+from fecfiler.committee_accounts.views import create_committee_view
+
+
+class TransactionDependenciesTestCase(TestCase):
+    def setUp(self):
+        self.committee = CommitteeAccount.objects.create(committee_id="C00000000")
+
+        create_committee_view(self.committee.id)
+        self.parent_contact = Contact.objects.create(
+            committee_account_id=self.committee.id, name="Parent Contact"
+        )
+
+    def test_get_jf_transfer_description(self):
+        """Test just the logic of generating the description"""
+        memo_prefix = "JF Memo:"
+        committee_name = "Committee Name"
+        is_attribution = False
+        expected = "JF Memo: Committee Name"
+        self.assertEqual(
+            get_jf_transfer_description(memo_prefix, committee_name, is_attribution),
+            expected,
+        )
+
+        is_attribution = True
+        expected = "JF Memo: Committee Name (Partnership Attribution)"
+        self.assertEqual(
+            get_jf_transfer_description(memo_prefix, committee_name, is_attribution),
+            expected,
+        )
+
+        memo_prefix = "Pres. Nominating Convention Account JF Memo:"
+        is_attribution = True
+        committee_name = "Committee Name That Is reeeeeeeeeeeeeeeeeeeeeeaaaaaaaaaaaaaaaaaaaaaaally Long"
+        expected = "Pres. Nominating Convention Account JF Memo: Committee Name That Is ree... (Partnership Attribution)"
+        self.assertEqual(
+            get_jf_transfer_description(memo_prefix, committee_name, is_attribution),
+            expected,
+        )
+
+    def test_update_dependent_descriptions(self):
+        """Test the full process of updating dependent transaction descriptions"""
+        parent_transaction = create_schedule_a(
+            "JOINT_FUNDRAISING_TRANSFER",
+            self.committee,
+            self.parent_contact,
+            "2020-01-01",
+            100,
+        )
+        child_transaction = create_schedule_a(
+            "INDIVIDUAL_JF_TRANSFER_MEMO",
+            self.committee,
+            self.parent_contact,
+            "2020-01-01",
+            100,
+        )
+        grandchild_transaction = create_schedule_a(
+            "PARTNERSHIP_ATTRIBUTION_JF_TRANSFER_MEMO",
+            self.committee,
+            self.parent_contact,
+            "2020-01-01",
+            100,
+        )
+        child_transaction.parent_transaction = parent_transaction
+        child_transaction.save()
+        grandchild_transaction.parent_transaction = child_transaction
+        grandchild_transaction.save()
+        self.assertIsNone(child_transaction.schedule_a.contribution_purpose_descrip)
+        self.assertIsNone(grandchild_transaction.schedule_a.contribution_purpose_descrip)
+        update_dependent_descriptions(parent_transaction)
+        child_transaction.refresh_from_db()
+        grandchild_transaction.refresh_from_db()
+        self.assertEquals(
+            child_transaction.schedule_a.contribution_purpose_descrip,
+            "JF Memo: Parent Contact",
+        )
+        self.assertEquals(
+            grandchild_transaction.schedule_a.contribution_purpose_descrip,
+            "JF Memo: Parent Contact (Partnership Attribution)",
+        )

--- a/django-backend/fecfiler/transactions/tests/test_transaction_dependencies.py
+++ b/django-backend/fecfiler/transactions/tests/test_transaction_dependencies.py
@@ -38,8 +38,14 @@ class TransactionDependenciesTestCase(TestCase):
 
         memo_prefix = "Pres. Nominating Convention Account JF Memo:"
         is_attribution = True
-        committee_name = "Committee Name That Is reeeeeeeeeeeeeeeeeeeeeeaaaaaaaaaaaaaaaaaaaaaaally Long"
-        expected = "Pres. Nominating Convention Account JF Memo: Committee Name That Is ree... (Partnership Attribution)"
+        committee_name = (
+            "Committee Name That Is "
+            + "reeeeeeeeeeeeeeeeeeeeeeaaaaaaaaaaaaaaaaaaaaaaally Long"
+        )
+        expected = (
+            "Pres. Nominating Convention Account JF Memo:"
+            + " Committee Name That Is ree... (Partnership Attribution)"
+        )
         self.assertEqual(
             get_jf_transfer_description(memo_prefix, committee_name, is_attribution),
             expected,

--- a/django-backend/fecfiler/transactions/transaction_dependencies.py
+++ b/django-backend/fecfiler/transactions/transaction_dependencies.py
@@ -1,0 +1,120 @@
+from fecfiler.transactions.schedule_a.models import ScheduleA
+from fecfiler.transactions.models import Transaction
+from django.db.models import Value, Case, When, F, Q
+
+
+def update_dependent_descriptions(transaction: Transaction):
+    """Joint Fundraising Transfer committee names must be updated in the contribution_purpose_descrip field of
+    dependent transactions."""
+    if transaction.transaction_type_identifier in JF_TRANSFER_DEPENDENCIES:
+        dependencies = JF_TRANSFER_DEPENDENCIES[transaction.transaction_type_identifier]
+        dependents = ScheduleA.objects.filter(
+            Q(
+                transaction__parent_transaction_id=transaction.id,
+                transaction__transaction_type_identifier__in=dependencies["children"],
+            )
+            | Q(
+                transaction__parent_transaction__parent_transaction_id=transaction.id,
+                transaction__transaction_type_identifier__in=dependencies[
+                    "grandchildren"
+                ],
+            )
+        )
+        update_expression = get_update_expression(transaction)
+        dependents.update(contribution_purpose_descrip=Value(update_expression))
+
+
+def get_jf_transfer_description(
+    memo_prefix: str, committee_name: str, is_attribution: bool
+):
+    """Generate a description for the dependent transaction of a joint fundraising transfer.
+    If it's an attribution, the description will include a parenthetical indicating that it's a partnership attribution.
+    """
+    committee_clause = f"{memo_prefix} {committee_name}"
+    if is_attribution:
+        parenthetical = "(Partnership Attribution)"
+        if len(committee_clause + parenthetical) > 100:
+            committee_clause = committee_clause[: 97 - len(parenthetical)] + "..."
+        return f"{committee_clause} {parenthetical}"
+    return committee_clause
+
+
+def get_update_expression(transaction: Transaction):
+    """Get the update expression for the dependent transaction descriptions.
+    The children will have different descriptions than the grandchildren.
+    """
+    dependencies = JF_TRANSFER_DEPENDENCIES[transaction.transaction_type_identifier]
+    children = dependencies["children"]
+    child_update = get_jf_transfer_description(
+        dependencies["prefix"], transaction.committee_name, False
+    )
+    grandchildren = dependencies["grandchildren"]
+    grandchild_update = get_jf_transfer_description(
+        dependencies["prefix"], transaction.committee_name, True
+    )
+    return Case(
+        When(
+            transaction__transaction_type_identifier__in=children,
+            then=Value(child_update),
+        ),
+        When(
+            transaction__transaction_type_identifier__in=grandchildren,
+            then=Value(grandchild_update),
+        ),
+        default=F("contribution_purpose_descrip"),
+    )
+
+
+# Dictionary of joint fundraising transfer dependencies.
+# Each key is a transaction type identifier that has dependent transactions.
+# The prefix is the same across all dependent transactions.
+# Specifies grandchildren because their description includes a parenthetical.
+JF_TRANSFER_DEPENDENCIES = {
+    "JOINT_FUNDRAISING_TRANSFER": {
+        "prefix": "JF Memo:",
+        "children": [
+            "INDIVIDUAL_JF_TRANSFER_MEMO",
+            "PAC_JF_TRANSFER_MEMO",
+            "PARTNERSHIP_JF_TRANSFER_MEMO",
+            "PARTY_JF_TRANSFER_MEMO",
+            "TRIBAL_JF_TRANSFER_MEMO",
+        ],
+        "grandchildren": ["PARTNERSHIP_ATTRIBUTION_JF_TRANSFER_MEMO"],
+    },
+    "JF_TRANSFER_NATIONAL_PARTY_CONVENTION_ACCOUNT": {
+        "prefix": "Pres. Nominating Convention Account JF Memo:",
+        "children": [
+            "INDIVIDUAL_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
+            "PAC_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
+            "PARTNERSHIP_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
+            "TRIBAL_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
+        ],
+        "grandchildren": [
+            "PARTNERSHIP_ATTRIBUTION_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO"
+        ],
+    },
+    "JF_TRANSFER_NATIONAL_PARTY_HEADQUARTERS_ACCOUNT": {
+        "prefix": "Headquarters Buildings Account JF Memo:",
+        "children": [
+            "INDIVIDUAL_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
+            "PAC_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
+            "PARTNERSHIP_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
+            "TRIBAL_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
+        ],
+        "grandchildren": [
+            "PARTNERSHIP_ATTRIBUTION_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO"
+        ],
+    },
+    "JF_TRANSFER_NATIONAL_PARTY_RECOUNT_ACCOUNT": {
+        "prefix": "Recount/Legal Proceedings Account JF Memo:",
+        "children": [
+            "INDIVIDUAL_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
+            "PAC_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
+            "PARTNERSHIP_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
+            "TRIBAL_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
+        ],
+        "grandchildren": [
+            "PARTNERSHIP_ATTRIBUTION_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO"
+        ],
+    },
+}

--- a/django-backend/fecfiler/transactions/transaction_dependencies.py
+++ b/django-backend/fecfiler/transactions/transaction_dependencies.py
@@ -38,8 +38,9 @@ def update_dependent_descriptions(transaction: Transaction):
         )
 
         """Update the contribution_purpose_descrip field for all dependent transactions.
-            Django does not support Case(When()) where the condition using other tables (transaction__).
-            So we use a Subquery to define the new description"""
+            Django does not support Case(When()) where the condition using joined tables (transaction__).
+            So we use a Subquery to define the new description
+            Ref: https://code.djangoproject.com/ticket/14104"""
         count = dependents.update(
             contribution_purpose_descrip=Subquery(
                 ScheduleA.objects.filter(id=OuterRef("id"))

--- a/django-backend/fecfiler/transactions/transaction_dependencies.py
+++ b/django-backend/fecfiler/transactions/transaction_dependencies.py
@@ -1,14 +1,14 @@
 from fecfiler.transactions.schedule_a.models import ScheduleA
 from fecfiler.transactions.models import Transaction
-from django.db.models import Value, Case, When, F, Q, Subquery, OuterRef
+from django.db.models import Value, Case, When, Q, Subquery, OuterRef
 import structlog
 
 logger = structlog.get_logger(__name__)
 
 
 def update_dependent_descriptions(transaction: Transaction):
-    """Joint Fundraising Transfer committee names must be updated in the contribution_purpose_descrip field of
-    dependent transactions."""
+    """Joint Fundraising Transfer committee names must be updated
+    in the contribution_purpose_descrip field of dependent transactions."""
     if transaction.transaction_type_identifier in JF_TRANSFER_DEPENDENCIES:
         dependencies = JF_TRANSFER_DEPENDENCIES[transaction.transaction_type_identifier]
 
@@ -17,7 +17,7 @@ def update_dependent_descriptions(transaction: Transaction):
         grandchildren = dependencies["grandchildren"]
 
         """The description for all children will be the same,
-            and the description for all grandchildren will be the same."""
+        and the description for all grandchildren will be the same."""
         child_update = get_jf_transfer_description(
             dependencies["prefix"], transaction.contact_1.name, False
         )
@@ -38,9 +38,11 @@ def update_dependent_descriptions(transaction: Transaction):
         )
 
         """Update the contribution_purpose_descrip field for all dependent transactions.
-            Django does not support Case(When()) where the condition using joined tables (transaction__).
-            So we use a Subquery to define the new description
-            Ref: https://code.djangoproject.com/ticket/14104"""
+        Django does not support Case(When()) where the condition using
+        joined tables (transaction__). So we use a Subquery to define
+        the new description
+
+        Ref: https://code.djangoproject.com/ticket/14104"""
         count = dependents.update(
             contribution_purpose_descrip=Subquery(
                 ScheduleA.objects.filter(id=OuterRef("id"))
@@ -62,9 +64,9 @@ def update_dependent_descriptions(transaction: Transaction):
 def get_jf_transfer_description(
     memo_prefix: str, committee_name: str, is_attribution: bool
 ):
-    """Generate a description for the dependent transaction of a joint fundraising transfer.
-    If it's an attribution, the description will include a parenthetical indicating that it's a partnership attribution.
-    """
+    """Generate a description for the dependent transaction of a joint
+    fundraising transfer. If it's an attribution, the description will
+    include a parenthetical indicating that it's a partnership attribution."""
     committee_clause = f"{memo_prefix} {committee_name}"
     if is_attribution:
         parenthetical = "(Partnership Attribution)"

--- a/django-backend/fecfiler/transactions/views.py
+++ b/django-backend/fecfiler/transactions/views.py
@@ -8,7 +8,7 @@ from rest_framework import status
 from rest_framework.viewsets import ModelViewSet
 from datetime import datetime
 from django.db.models import Q
-from fecfiler.transactions.transaction_dependencies import TransactionDependenciesUtils
+from fecfiler.transactions.transaction_dependencies import update_dependent_descriptions
 from fecfiler.committee_accounts.views import CommitteeOwnedViewMixin
 from fecfiler.transactions.models import (
     Transaction,
@@ -324,7 +324,7 @@ class TransactionViewSet(CommitteeOwnedViewMixin, ModelViewSet):
         EXAMPLE: if this transaction is a JF transfer, update the descriptions of its
         children and grandchildren transactions with any changes to the committee name
         """
-        TransactionDependenciesUtils().update_dependent_descriptions(transaction_instance)
+        update_dependent_descriptions(transaction_instance)
 
         return self.queryset.get(id=transaction_instance.id)
 

--- a/django-backend/fecfiler/transactions/views.py
+++ b/django-backend/fecfiler/transactions/views.py
@@ -7,7 +7,8 @@ from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.viewsets import ModelViewSet
 from datetime import datetime
-from django.db.models import Q
+from django.db.models import Q, Value
+from django.db.models.functions import Concat
 from fecfiler.committee_accounts.views import CommitteeOwnedViewMixin
 from fecfiler.transactions.models import (
     Transaction,
@@ -44,15 +45,15 @@ class TransactionOrderingFilter(OrderingFilter):
         ordering_fields = getattr(view, "ordering_fields", [])
 
         if ordering_query_param:
-            fields = [param.strip() for param in ordering_query_param.split(',')]
+            fields = [param.strip() for param in ordering_query_param.split(",")]
             ordering = []
             for field in fields:
-                if field.strip('-') in ordering_fields:
-                    if field == '-memo_code' and not (
+                if field.strip("-") in ordering_fields:
+                    if field == "-memo_code" and not (
                         queryset.filter(memo_code=True).exists()
                         and queryset.exclude(memo_code=True).exists()
                     ):
-                        field = 'memo_code'
+                        field = "memo_code"
                     ordering.append(field)
             if ordering:
                 return ordering
@@ -319,6 +320,8 @@ class TransactionViewSet(CommitteeOwnedViewMixin, ModelViewSet):
 
                 self.save_transaction(child_transaction_data, request)
 
+        update_dependent_descriptions(transaction_instance)
+
         return self.queryset.get(id=transaction_instance.id)
 
     @action(detail=False, methods=["put"], url_path=r"multisave/reattribution")
@@ -405,3 +408,156 @@ def stringify_queryset(qs):
         s = cursor.mogrify(sql, params)
     conn.close()
     return s
+
+
+def update_dependent_descriptions(transaction: Transaction):
+
+    dependencies = {
+        "JOINT_FUNDRAISING_TRANSFER": {
+            "method": get_jf_transfer_child_description_clause,
+            "children": [
+                "INDIVIDUAL_JF_TRANSFER_MEMO",
+                "PAC_JF_TRANSFER_MEMO",
+                "PARTNERSHIP_JF_TRANSFER_MEMO",
+                "PARTY_JF_TRANSFER_MEMO",
+                "TRIBAL_JF_TRANSFER_MEMO",
+            ],
+        },
+        "JF_TRANSFER_NATIONAL_PARTY_CONVENTION_ACCOUNT": {
+            "method": get_jf_transfer_national_party_convention_account_child_description_clause,
+            "children": [
+                "INDIVIDUAL_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
+                "PAC_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
+                "PARTNERSHIP_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
+                "TRIBAL_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
+            ],
+        },
+        "JF_TRANSFER_NATIONAL_PARTY_HEADQUARTERS_ACCOUNT": {
+            "method": get_jf_transfer_national_party_headquarters_account_child_description_clause,
+            "children": [
+                "INDIVIDUAL_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
+                "PAC_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
+                "PARTNERSHIP_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
+                "TRIBAL_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
+            ],
+        },
+        "JF_TRANSFER_NATIONAL_PARTY_RECOUNT_ACCOUNT": {
+            "method": get_jf_transfer_national_party_recount_account_child_description_clause,
+            "children": [
+                "INDIVIDUAL_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
+                "PAC_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
+                "PARTNERSHIP_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
+                "TRIBAL_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
+            ],
+        },
+    }
+    child_transaction_type_ids = {
+        "JOINT_FUNDRAISING_TRANSFER": [
+            "INDIVIDUAL_JF_TRANSFER_MEMO",
+            "PAC_JF_TRANSFER_MEMO",
+            # 'PARTNERSHIP_JF_TRANSFER_MEMO',
+            "PARTY_JF_TRANSFER_MEMO",
+            "TRIBAL_JF_TRANSFER_MEMO",
+        ],
+        "JF_TRANSFER_NATIONAL_PARTY_CONVENTION_ACCOUNT": [
+            "INDIVIDUAL_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
+            "PAC_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
+            "PARTNERSHIP_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
+            "TRIBAL_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
+        ],
+        "JF_TRANSFER_NATIONAL_PARTY_HEADQUARTERS_ACCOUNT": [
+            "INDIVIDUAL_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
+            "PAC_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
+            "PARTNERSHIP_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
+            "TRIBAL_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
+        ],
+        "JF_TRANSFER_NATIONAL_PARTY_RECOUNT_ACCOUNT": [
+            "INDIVIDUAL_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
+            "PAC_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
+            "PARTNERSHIP_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
+            "TRIBAL_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
+        ],
+        "PARTNERSHIP_JF_TRANSFER_MEMO": [
+            "PARTNERSHIP_ATTRIBUTION_JF_TRANSFER_MEMO",
+        ],
+        "PARTNERSHIP_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO": [
+            "PARTNERSHIP_ATTRIBUTION_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
+        ],
+        "PARTNERSHIP_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO": [
+            "PARTNERSHIP_ATTRIBUTION_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
+        ],
+        "PARTNERSHIP_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO": [
+            "PARTNERSHIP_ATTRIBUTION_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
+        ],
+    }
+
+    if transaction.transaction_type_identifier in dependencies:
+
+        if dependencies[transaction.transaction_type_identifier]["children"]:
+            # Fetch all child transactions for the given parent_transaction_id
+            children = Transaction.objects.filter(
+                parent_transaction_id=transaction.id,
+                transaction_type_identifier__in=dependencies[
+                    transaction.transaction_type_identifier
+                ]["children"],
+            )
+            description_clause = dependencies[transaction.transaction_type_identifier][
+                "method"
+            ](transaction)
+            children.update(contribution_purpose_descrip=description_clause)
+
+
+def get_jf_transfer_child_description_clause(transaction: Transaction) -> str:
+    return Concat(Value(">>> JF Memo: "), transaction.contributor_organization_name)
+
+
+def get_jf_transfer_national_party_convention_account_child_description_clause(
+    transaction: Transaction,
+) -> str:
+    return Concat(
+        Value(">>> Pres. Nominating Convention Account JF Memo: "),
+        transaction.contributor_organization_name,
+    )
+
+
+def get_jf_transfer_national_party_headquarters_account_child_description_clause(
+    transaction: Transaction,
+) -> str:
+    return Concat(
+        Value(">>> Headquarters Buildings Account JF Memo: "),
+        transaction.contributor_organization_name,
+    )
+
+
+def get_jf_transfer_national_party_recount_account_child_description_clause(
+    transaction: Transaction,
+) -> str:
+    return Concat(
+        Value(">>> Recount/Legal Proceedings Account JF Memo: "),
+        transaction.contributor_organization_name,
+    )
+
+
+def update_description_text(
+    transaction: Transaction, child_transaction_type_identifier: str
+) -> str:
+    if child_transaction_type_identifier == "INDIVIDUAL_JF_TRANSFER_MEMO":
+        return f">>> JF Memo: {transaction.contributor_organization_name}"
+    elif child_transaction_type_identifier == "PAC_JF_TRANSFER_MEMO":
+        return f">>> JF Memo: {transaction.contributor_organization_name}"
+    # elif child_transaction_type_identifier == 'PARTNERSHIP_JF_TRANSFER_MEMO':
+
+    #     committee_clause = f">>> JF Memo: {transaction.contributor_organization_name}"
+    #     const hasChildren = transaction.children && transaction.children.length > 0;
+    #     const parenthetical = hasChildren
+    #     ? ' (See Partnership Attribution(s) below)'
+    #     : ' (Partnership attributions do not meet itemization threshold)'
+    #     if ((committee_clause + parenthetical).length > 100) {
+    #     committee_clause = committee_clause.slice(0, 97 - parenthetical.length) + '...'
+    #     }
+    #     return committeeClause + parenthetical
+
+    elif child_transaction_type_identifier == "PARTY_JF_TRANSFER_MEMO":
+        return f">>> JF Memo: {transaction.contributor_organization_name}"
+    elif child_transaction_type_identifier == "TRIBAL_JF_TRANSFER_MEMO":
+        return f">>> JF Memo: {transaction.contributor_organization_name}"

--- a/django-backend/fecfiler/transactions/views.py
+++ b/django-backend/fecfiler/transactions/views.py
@@ -7,8 +7,8 @@ from rest_framework.response import Response
 from rest_framework import status
 from rest_framework.viewsets import ModelViewSet
 from datetime import datetime
-from django.db.models import Q, Value
-from django.db.models.functions import Concat
+from django.db.models import Q
+from fecfiler.transactions.transaction_dependencies import TransactionDependenciesUtils
 from fecfiler.committee_accounts.views import CommitteeOwnedViewMixin
 from fecfiler.transactions.models import (
     Transaction,
@@ -320,7 +320,11 @@ class TransactionViewSet(CommitteeOwnedViewMixin, ModelViewSet):
 
                 self.save_transaction(child_transaction_data, request)
 
-        update_dependent_descriptions(transaction_instance)
+        """ trigger updates to transactions with fields that depend on this one
+        EXAMPLE: if this transaction is a JF transfer, update the descriptions of its
+        children and grandchildren transactions with any changes to the committee name
+        """
+        TransactionDependenciesUtils().update_dependent_descriptions(transaction_instance)
 
         return self.queryset.get(id=transaction_instance.id)
 
@@ -408,156 +412,3 @@ def stringify_queryset(qs):
         s = cursor.mogrify(sql, params)
     conn.close()
     return s
-
-
-def update_dependent_descriptions(transaction: Transaction):
-
-    dependencies = {
-        "JOINT_FUNDRAISING_TRANSFER": {
-            "method": get_jf_transfer_child_description_clause,
-            "children": [
-                "INDIVIDUAL_JF_TRANSFER_MEMO",
-                "PAC_JF_TRANSFER_MEMO",
-                "PARTNERSHIP_JF_TRANSFER_MEMO",
-                "PARTY_JF_TRANSFER_MEMO",
-                "TRIBAL_JF_TRANSFER_MEMO",
-            ],
-        },
-        "JF_TRANSFER_NATIONAL_PARTY_CONVENTION_ACCOUNT": {
-            "method": get_jf_transfer_national_party_convention_account_child_description_clause,
-            "children": [
-                "INDIVIDUAL_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
-                "PAC_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
-                "PARTNERSHIP_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
-                "TRIBAL_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
-            ],
-        },
-        "JF_TRANSFER_NATIONAL_PARTY_HEADQUARTERS_ACCOUNT": {
-            "method": get_jf_transfer_national_party_headquarters_account_child_description_clause,
-            "children": [
-                "INDIVIDUAL_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
-                "PAC_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
-                "PARTNERSHIP_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
-                "TRIBAL_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
-            ],
-        },
-        "JF_TRANSFER_NATIONAL_PARTY_RECOUNT_ACCOUNT": {
-            "method": get_jf_transfer_national_party_recount_account_child_description_clause,
-            "children": [
-                "INDIVIDUAL_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
-                "PAC_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
-                "PARTNERSHIP_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
-                "TRIBAL_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
-            ],
-        },
-    }
-    child_transaction_type_ids = {
-        "JOINT_FUNDRAISING_TRANSFER": [
-            "INDIVIDUAL_JF_TRANSFER_MEMO",
-            "PAC_JF_TRANSFER_MEMO",
-            # 'PARTNERSHIP_JF_TRANSFER_MEMO',
-            "PARTY_JF_TRANSFER_MEMO",
-            "TRIBAL_JF_TRANSFER_MEMO",
-        ],
-        "JF_TRANSFER_NATIONAL_PARTY_CONVENTION_ACCOUNT": [
-            "INDIVIDUAL_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
-            "PAC_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
-            "PARTNERSHIP_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
-            "TRIBAL_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
-        ],
-        "JF_TRANSFER_NATIONAL_PARTY_HEADQUARTERS_ACCOUNT": [
-            "INDIVIDUAL_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
-            "PAC_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
-            "PARTNERSHIP_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
-            "TRIBAL_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
-        ],
-        "JF_TRANSFER_NATIONAL_PARTY_RECOUNT_ACCOUNT": [
-            "INDIVIDUAL_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
-            "PAC_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
-            "PARTNERSHIP_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
-            "TRIBAL_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
-        ],
-        "PARTNERSHIP_JF_TRANSFER_MEMO": [
-            "PARTNERSHIP_ATTRIBUTION_JF_TRANSFER_MEMO",
-        ],
-        "PARTNERSHIP_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO": [
-            "PARTNERSHIP_ATTRIBUTION_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
-        ],
-        "PARTNERSHIP_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO": [
-            "PARTNERSHIP_ATTRIBUTION_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
-        ],
-        "PARTNERSHIP_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO": [
-            "PARTNERSHIP_ATTRIBUTION_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
-        ],
-    }
-
-    if transaction.transaction_type_identifier in dependencies:
-
-        if dependencies[transaction.transaction_type_identifier]["children"]:
-            # Fetch all child transactions for the given parent_transaction_id
-            children = Transaction.objects.filter(
-                parent_transaction_id=transaction.id,
-                transaction_type_identifier__in=dependencies[
-                    transaction.transaction_type_identifier
-                ]["children"],
-            )
-            description_clause = dependencies[transaction.transaction_type_identifier][
-                "method"
-            ](transaction)
-            children.update(contribution_purpose_descrip=description_clause)
-
-
-def get_jf_transfer_child_description_clause(transaction: Transaction) -> str:
-    return Concat(Value(">>> JF Memo: "), transaction.contributor_organization_name)
-
-
-def get_jf_transfer_national_party_convention_account_child_description_clause(
-    transaction: Transaction,
-) -> str:
-    return Concat(
-        Value(">>> Pres. Nominating Convention Account JF Memo: "),
-        transaction.contributor_organization_name,
-    )
-
-
-def get_jf_transfer_national_party_headquarters_account_child_description_clause(
-    transaction: Transaction,
-) -> str:
-    return Concat(
-        Value(">>> Headquarters Buildings Account JF Memo: "),
-        transaction.contributor_organization_name,
-    )
-
-
-def get_jf_transfer_national_party_recount_account_child_description_clause(
-    transaction: Transaction,
-) -> str:
-    return Concat(
-        Value(">>> Recount/Legal Proceedings Account JF Memo: "),
-        transaction.contributor_organization_name,
-    )
-
-
-def update_description_text(
-    transaction: Transaction, child_transaction_type_identifier: str
-) -> str:
-    if child_transaction_type_identifier == "INDIVIDUAL_JF_TRANSFER_MEMO":
-        return f">>> JF Memo: {transaction.contributor_organization_name}"
-    elif child_transaction_type_identifier == "PAC_JF_TRANSFER_MEMO":
-        return f">>> JF Memo: {transaction.contributor_organization_name}"
-    # elif child_transaction_type_identifier == 'PARTNERSHIP_JF_TRANSFER_MEMO':
-
-    #     committee_clause = f">>> JF Memo: {transaction.contributor_organization_name}"
-    #     const hasChildren = transaction.children && transaction.children.length > 0;
-    #     const parenthetical = hasChildren
-    #     ? ' (See Partnership Attribution(s) below)'
-    #     : ' (Partnership attributions do not meet itemization threshold)'
-    #     if ((committee_clause + parenthetical).length > 100) {
-    #     committee_clause = committee_clause.slice(0, 97 - parenthetical.length) + '...'
-    #     }
-    #     return committeeClause + parenthetical
-
-    elif child_transaction_type_identifier == "PARTY_JF_TRANSFER_MEMO":
-        return f">>> JF Memo: {transaction.contributor_organization_name}"
-    elif child_transaction_type_identifier == "TRIBAL_JF_TRANSFER_MEMO":
-        return f">>> JF Memo: {transaction.contributor_organization_name}"


### PR DESCRIPTION
Example:
A JOINT_FUNDRAISING_TRANSFER with an INDIVIDUAL_JF_TRANSFER_MEMO child and
a PARTNERSHIP_ATTRIBUTION_JF_TRANSFER_MEMO grandchild is updated. The description for
the child will be "JF Memo: Committee Name" and the description for the grandchild will be
"JF Memo: Committee Name (Partnership Attribution)".

This Branch takes on that responsibility in the back end

Note: does not update parent transactions that depend on a child.