### PR TITLE
feature/1468 - Remove transaction ids from report serializer

### DIFF
--- a/django-backend/fecfiler/reports/serializers.py
+++ b/django-backend/fecfiler/reports/serializers.py
@@ -160,6 +160,7 @@ class ReportSerializer(CommitteeOwnedSerializer, FecSchemaValidatorSerializerMix
                     "webprintsubmission",
                     "memotext",
                     "transaction",
+                    "transactions",
                     "dotfec",
                     "report",
                     "reporttransaction",


### PR DESCRIPTION
Did some digging in the front end and it appears we aren't even using transactions field of the reports at all any longer.