### PR TITLE
update transaction dependencies to handle partnership memos correctly

### DIFF
--- a/django-backend/fecfiler/transactions/tests/test_transaction_dependencies.py
+++ b/django-backend/fecfiler/transactions/tests/test_transaction_dependencies.py
@@ -25,7 +25,8 @@ class TransactionDependenciesTestCase(TestCase):
         expected = (
             "JF Memo: Committee Name",
             "JF Memo: Committee Name (Partnership Attribution)",
-            "JF Memo: Committee Name (Partnership attributions do not meet itemization threshold)",
+            "JF Memo: Committee Name (Partnership attributions do"
+            + " not meet itemization threshold)",
             "JF Memo: Committee Name (See Partnership Attribution(s) below)",
         )
         self.assertEqual(
@@ -39,7 +40,8 @@ class TransactionDependenciesTestCase(TestCase):
         )
         expected = (
             "Pres. Nominating Convention Account JF Memo:"
-            + " Committee Name That Is reeeeeeeeeeeeeeeeeeeeeeaaaaaaaaaaaaaaaaaaaaaaally Long",
+            + " Committee Name That Is"
+            + " reeeeeeeeeeeeeeeeeeeeeeaaaaaaaaaaaaaaaaaaaaaaally Long",
             "Pres. Nominating Convention Account JF Memo:"
             + " Committee Name That Is ree... (Partnership Attribution)",
             "Pres. Nominating Convention Account"
@@ -100,11 +102,13 @@ class TransactionDependenciesTestCase(TestCase):
         partnership_memo.refresh_from_db()
         self.assertEquals(
             partnership_memo.schedule_a.contribution_purpose_descrip,
-            "JF Memo: Parent Contact (Partnership attributions do not meet itemization threshold)",
+            "JF Memo: Parent Contact"
+            + " (Partnership attributions do not meet itemization threshold)",
         )
 
     def test_jf_partnership_memo_with_attribution(self):
-        """Test the full process of updating the description for a JF partnership memo with an attribution"""
+        """Test the full process of updating the description
+        for a JF partnership memo with an attribution"""
         jf_transfer = create_schedule_a(
             "JOINT_FUNDRAISING_TRANSFER",
             self.committee,

--- a/django-backend/fecfiler/transactions/tests/test_transaction_dependencies.py
+++ b/django-backend/fecfiler/transactions/tests/test_transaction_dependencies.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from fecfiler.committee_accounts.models import CommitteeAccount
 from fecfiler.contacts.models import Contact
 from fecfiler.transactions.transaction_dependencies import (
-    get_jf_transfer_description,
+    get_jf_transfer_descriptions,
     update_dependent_descriptions,
 )
 from fecfiler.transactions.tests.utils import create_schedule_a
@@ -18,76 +18,128 @@ class TransactionDependenciesTestCase(TestCase):
             committee_account_id=self.committee.id, name="Parent Contact"
         )
 
-    def test_get_jf_transfer_description(self):
-        """Test just the logic of generating the description"""
+    def test_get_jf_transfer_descriptions(self):
+        """Test just the logic of generating all the descriptions"""
         memo_prefix = "JF Memo:"
         committee_name = "Committee Name"
-        is_attribution = False
-        expected = "JF Memo: Committee Name"
-        self.assertEqual(
-            get_jf_transfer_description(memo_prefix, committee_name, is_attribution),
-            expected,
+        expected = (
+            "JF Memo: Committee Name",
+            "JF Memo: Committee Name (Partnership Attribution)",
+            "JF Memo: Committee Name (Partnership attributions do not meet itemization threshold)",
+            "JF Memo: Committee Name (See Partnership Attribution(s) below)",
         )
-
-        is_attribution = True
-        expected = "JF Memo: Committee Name (Partnership Attribution)"
         self.assertEqual(
-            get_jf_transfer_description(memo_prefix, committee_name, is_attribution),
-            expected,
+            get_jf_transfer_descriptions(memo_prefix, committee_name), expected
         )
 
         memo_prefix = "Pres. Nominating Convention Account JF Memo:"
-        is_attribution = True
         committee_name = (
             "Committee Name That Is "
             + "reeeeeeeeeeeeeeeeeeeeeeaaaaaaaaaaaaaaaaaaaaaaally Long"
         )
         expected = (
             "Pres. Nominating Convention Account JF Memo:"
-            + " Committee Name That Is ree... (Partnership Attribution)"
+            + " Committee Name That Is reeeeeeeeeeeeeeeeeeeeeeaaaaaaaaaaaaaaaaaaaaaaally Long",
+            "Pres. Nominating Convention Account JF Memo:"
+            + " Committee Name That Is ree... (Partnership Attribution)",
+            "Pres. Nominating Convention Account"
+            + " ... (Partnership attributions do not meet itemization threshold)",
+            "Pres. Nominating Convention Account JF Memo:"
+            + " Committee Nam... (See Partnership Attribution(s) below)",
         )
         self.assertEqual(
-            get_jf_transfer_description(memo_prefix, committee_name, is_attribution),
-            expected,
+            get_jf_transfer_descriptions(memo_prefix, committee_name), expected
         )
 
-    def test_update_dependent_descriptions(self):
-        """Test the full process of updating dependent transaction descriptions"""
-        parent_transaction = create_schedule_a(
+    def test_jf_memo(self):
+        """Test the full process of updating the description for a JF memo"""
+        jf_transfer = create_schedule_a(
             "JOINT_FUNDRAISING_TRANSFER",
             self.committee,
             self.parent_contact,
             "2020-01-01",
             100,
         )
-        child_transaction = create_schedule_a(
+        jf_memo = create_schedule_a(
             "INDIVIDUAL_JF_TRANSFER_MEMO",
             self.committee,
             self.parent_contact,
             "2020-01-01",
             100,
         )
-        grandchild_transaction = create_schedule_a(
+        jf_memo.parent_transaction = jf_transfer
+        jf_memo.save()
+        self.assertIsNone(jf_memo.schedule_a.contribution_purpose_descrip)
+        update_dependent_descriptions(jf_transfer)
+        jf_memo.refresh_from_db()
+        self.assertEquals(
+            jf_memo.schedule_a.contribution_purpose_descrip,
+            "JF Memo: Parent Contact",
+        )
+
+    def test_jf_partnership_memo(self):
+        """Test the full process of updating the description for a JF partnership memo"""
+        jf_transfer = create_schedule_a(
+            "JOINT_FUNDRAISING_TRANSFER",
+            self.committee,
+            self.parent_contact,
+            "2020-01-01",
+            100,
+        )
+        partnership_memo = create_schedule_a(
+            "PARTNERSHIP_JF_TRANSFER_MEMO",
+            self.committee,
+            self.parent_contact,
+            "2020-01-01",
+            100,
+        )
+        partnership_memo.parent_transaction = jf_transfer
+        partnership_memo.save()
+        self.assertIsNone(partnership_memo.schedule_a.contribution_purpose_descrip)
+        update_dependent_descriptions(jf_transfer)
+        partnership_memo.refresh_from_db()
+        self.assertEquals(
+            partnership_memo.schedule_a.contribution_purpose_descrip,
+            "JF Memo: Parent Contact (Partnership attributions do not meet itemization threshold)",
+        )
+
+    def test_jf_partnership_memo_with_attribution(self):
+        """Test the full process of updating the description for a JF partnership memo with an attribution"""
+        jf_transfer = create_schedule_a(
+            "JOINT_FUNDRAISING_TRANSFER",
+            self.committee,
+            self.parent_contact,
+            "2020-01-01",
+            100,
+        )
+        partnership_memo = create_schedule_a(
+            "PARTNERSHIP_JF_TRANSFER_MEMO",
+            self.committee,
+            self.parent_contact,
+            "2020-01-01",
+            100,
+        )
+        partnership_memo.parent_transaction = jf_transfer
+        partnership_memo.save()
+        attribution_memo = create_schedule_a(
             "PARTNERSHIP_ATTRIBUTION_JF_TRANSFER_MEMO",
             self.committee,
             self.parent_contact,
             "2020-01-01",
             100,
         )
-        child_transaction.parent_transaction = parent_transaction
-        child_transaction.save()
-        grandchild_transaction.parent_transaction = child_transaction
-        grandchild_transaction.save()
-        self.assertIsNone(child_transaction.schedule_a.contribution_purpose_descrip)
-        self.assertIsNone(grandchild_transaction.schedule_a.contribution_purpose_descrip)
-        update_dependent_descriptions(parent_transaction)
-        child_transaction.refresh_from_db()
-        grandchild_transaction.refresh_from_db()
+        attribution_memo.parent_transaction = partnership_memo
+        attribution_memo.save()
+        self.assertIsNone(partnership_memo.schedule_a.contribution_purpose_descrip)
+        self.assertIsNone(attribution_memo.schedule_a.contribution_purpose_descrip)
+        update_dependent_descriptions(jf_transfer)
+        partnership_memo.refresh_from_db()
+        attribution_memo.refresh_from_db()
         self.assertEquals(
-            child_transaction.schedule_a.contribution_purpose_descrip,
-            "JF Memo: Parent Contact",
+            partnership_memo.schedule_a.contribution_purpose_descrip,
+            "JF Memo: Parent Contact (See Partnership Attribution(s) below)",
         )
         self.assertEquals(
-            grandchild_transaction.schedule_a.contribution_purpose_descrip,
+            attribution_memo.schedule_a.contribution_purpose_descrip,
             "JF Memo: Parent Contact (Partnership Attribution)",
         )

--- a/django-backend/fecfiler/transactions/transaction_dependencies.py
+++ b/django-backend/fecfiler/transactions/transaction_dependencies.py
@@ -91,9 +91,13 @@ def get_jf_transfer_descriptions(memo_prefix: str, commmittee_name: str):
     """Generate descriptions for the dependent transactions of a joint
     fundraising transfer. There are 4 descriptions:
     1. The description for most children transactions (ex: "JF Memo: Committee Name")
-    2. The description for grandchildren transactions (ex: "JF Memo: Committee Name (Partnership Attribution)")
-    3. The description for partnership memos with no grandchildren (ex: "JF Memo: Committee Name (Partnership attributions do not meet itemization threshold)")
-    4. The description for partnership memos with grandchildren (ex: "JF Memo: Committee Name (See Partnership Attribution(s) below)")
+    2. The description for grandchildren transactions
+        (ex: "JF Memo: Committee Name (Partnership Attribution)")
+    3. The description for partnership memos with no grandchildren
+        (ex: "JF Memo: Committee Name (Partnership attributions do not meet
+          itemization threshold)")
+    4. The description for partnership memos with grandchildren
+        (ex: "JF Memo: Committee Name (See Partnership Attribution(s) below)")
     """
     committee_clause = f"{memo_prefix} {commmittee_name}"
     attribution_description = get_truncated_description(

--- a/django-backend/fecfiler/transactions/transaction_dependencies.py
+++ b/django-backend/fecfiler/transactions/transaction_dependencies.py
@@ -1,6 +1,6 @@
 from fecfiler.transactions.schedule_a.models import ScheduleA
 from fecfiler.transactions.models import Transaction
-from django.db.models import Value, Case, When, Q, Subquery, OuterRef
+from django.db.models import Value, Case, When, Q, Subquery, OuterRef, Exists
 import structlog
 
 logger = structlog.get_logger(__name__)
@@ -15,15 +15,6 @@ def update_dependent_descriptions(transaction: Transaction):
         """Identify the transaction types to update"""
         children = dependencies["children"]
         grandchildren = dependencies["grandchildren"]
-
-        """The description for all children will be the same,
-        and the description for all grandchildren will be the same."""
-        child_update = get_jf_transfer_description(
-            dependencies["prefix"], transaction.contact_1.name, False
-        )
-        grandchild_update = get_jf_transfer_description(
-            dependencies["prefix"], transaction.contact_1.name, True
-        )
 
         """Establish the queryset with all dependent transactions"""
         dependents = ScheduleA.objects.filter(
@@ -47,12 +38,8 @@ def update_dependent_descriptions(transaction: Transaction):
             contribution_purpose_descrip=Subquery(
                 ScheduleA.objects.filter(id=OuterRef("id"))
                 .annotate(
-                    new_description=Case(
-                        When(
-                            transaction__parent_transaction_id=transaction.id,
-                            then=Value(child_update),
-                        ),
-                        default=Value(grandchild_update),
+                    new_description=get_new_description_clause(
+                        dependencies["prefix"], transaction.contact_1.name, transaction.id
                     )
                 )
                 .values("new_description")[:1]
@@ -61,19 +48,78 @@ def update_dependent_descriptions(transaction: Transaction):
         logger.debug(f"Updated {count} dependent transactions for {transaction}")
 
 
-def get_jf_transfer_description(
-    memo_prefix: str, committee_name: str, is_attribution: bool
+def get_new_description_clause(
+    memo_prefix: str, commmittee_name: str, transaction_id: str
 ):
-    """Generate a description for the dependent transaction of a joint
-    fundraising transfer. If it's an attribution, the description will
-    include a parenthetical indicating that it's a partnership attribution."""
-    committee_clause = f"{memo_prefix} {committee_name}"
-    if is_attribution:
-        parenthetical = "(Partnership Attribution)"
-        if len(committee_clause + parenthetical) > 100:
-            committee_clause = committee_clause[: 96 - len(parenthetical)] + "..."
-        return f"{committee_clause} {parenthetical}"
-    return committee_clause
+    """Generate Django Expression to update the contribution_purpose_descrip field"""
+
+    """Create descriptions to be used by different dependents."""
+    (
+        child_update,
+        attribution_update,
+        partnership_no_children_update,
+        partnership_with_children_update,
+    ) = get_jf_transfer_descriptions(memo_prefix, commmittee_name)
+
+    has_children = Exists(
+        Transaction.objects.filter(
+            parent_transaction_id=OuterRef("transaction__id")
+        ).values("id")[:1]
+    )
+
+    partnership_case = Case(
+        When(has_children, then=Value(partnership_with_children_update)),
+        default=Value(partnership_no_children_update),
+    )
+    child_case = Case(
+        When(
+            transaction__transaction_type_identifier__in=PARTNERSHIP_MEMOS,
+            then=partnership_case,
+        ),
+        default=Value(child_update),
+    )
+    return Case(
+        When(
+            transaction__parent_transaction_id=transaction_id,
+            then=child_case,
+        ),
+        default=Value(attribution_update),
+    )
+
+
+def get_jf_transfer_descriptions(memo_prefix: str, commmittee_name: str):
+    """Generate descriptions for the dependent transactions of a joint
+    fundraising transfer. There are 4 descriptions:
+    1. The description for most children transactions (ex: "JF Memo: Committee Name")
+    2. The description for grandchildren transactions (ex: "JF Memo: Committee Name (Partnership Attribution)")
+    3. The description for partnership memos with no grandchildren (ex: "JF Memo: Committee Name (Partnership attributions do not meet itemization threshold)")
+    4. The description for partnership memos with grandchildren (ex: "JF Memo: Committee Name (See Partnership Attribution(s) below)")
+    """
+    committee_clause = f"{memo_prefix} {commmittee_name}"
+    attribution_description = get_truncated_description(
+        committee_clause, "(Partnership Attribution)"
+    )
+    partnership_description_no_children = get_truncated_description(
+        committee_clause, "(Partnership attributions do not meet itemization threshold)"
+    )
+    partnership_description_with_children = get_truncated_description(
+        committee_clause, "(See Partnership Attribution(s) below)"
+    )
+
+    return (
+        committee_clause,
+        attribution_description,
+        partnership_description_no_children,
+        partnership_description_with_children,
+    )
+
+
+def get_truncated_description(description: str, parenthetical: str):
+    """Truncate the description to fit within the 100 character limit
+    and append a parenthetical."""
+    if len(description + parenthetical) > 100:
+        description = description[: 96 - len(parenthetical)] + "..."
+    return f"{description} {parenthetical}"
 
 
 # Dictionary of joint fundraising transfer dependencies.
@@ -129,3 +175,11 @@ JF_TRANSFER_DEPENDENCIES = {
         ],
     },
 }
+
+# List of transaction types that are partnership memos.
+PARTNERSHIP_MEMOS = [
+    "PARTNERSHIP_JF_TRANSFER_MEMO",
+    "PARTNERSHIP_NATIONAL_PARTY_CONVENTION_JF_TRANSFER_MEMO",
+    "PARTNERSHIP_NATIONAL_PARTY_HEADQUARTERS_JF_TRANSFER_MEMO",
+    "PARTNERSHIP_NATIONAL_PARTY_RECOUNT_JF_TRANSFER_MEMO",
+]


### PR DESCRIPTION
I broke the descriptions of partnership memos with 1481.

This adds handling for the case when a partnership memo is updated as a dependency.  It's description will depend on whether or not it has children