### PR TITLE
1547 - Add related mock env variables to each cloud space

### DIFF
--- a/manifests/manifest-dev-api.yml
+++ b/manifests/manifest-dev-api.yml
@@ -26,3 +26,4 @@ applications:
       BP_PIP_VERSION: latest
       LOG_FORMAT: KEY_VALUE
       MOCK_OPENFEC: REDIS
+      MOCK_EFO: true

--- a/manifests/manifest-prod-api.yml
+++ b/manifests/manifest-prod-api.yml
@@ -22,6 +22,7 @@ applications:
       LOGIN_REDIRECT_SERVER_URL: https://api.fecfile.fec.gov/api/v1/oidc/login-redirect
       LOGOUT_REDIRECT_URL: https://api.fecfile.fec.gov/api/v1/oidc/logout-redirect
       FEC_API: https://api.open.fec.gov/v1/
+      FEC_FILING_API: https://efoservices.stage.efo.fec.gov
       SESSION_COOKIE_AGE: 64800
       BP_PIP_VERSION: latest
       LOG_FORMAT: KEY_VALUE

--- a/manifests/manifest-stage-api.yml
+++ b/manifests/manifest-stage-api.yml
@@ -22,6 +22,7 @@ applications:
       LOGIN_REDIRECT_SERVER_URL: https://stage-api.fecfile.fec.gov/api/v1/oidc/login-redirect
       LOGOUT_REDIRECT_URL: https://stage-api.fecfile.fec.gov/api/v1/oidc/logout-redirect
       FEC_API: https://api.open.fec.gov/v1/
+      FEC_FILING_API: https://efoservices.stage.efo.fec.gov
       SESSION_COOKIE_AGE: 64800
       BP_PIP_VERSION: latest
       LOG_FORMAT: KEY_VALUE


### PR DESCRIPTION
Entries were made into the DEV, STAGE, and PROD manifests so that the appropriate environment variables for set for each respective cloud space.