### PR TITLE
feature/1634 - josepy snyk report

### DIFF
--- a/django-backend/fecfiler/oidc/tests/test_backends.py
+++ b/django-backend/fecfiler/oidc/tests/test_backends.py
@@ -24,166 +24,16 @@ class OIDCAuthenticationBackendTestCase(TestCase):
             self.backend.authenticate(request=auth_request)
 
     @patch("fecfiler.oidc.backends.requests")
+    @patch("fecfiler.oidc.backends.jwk")
     @patch("fecfiler.oidc.backends.jwt")
-    @patch("fecfiler.oidc.backends.JWS")
-    def test_authenticate_invalid_jwks(
-        self,
-        jws_mock,
-        jwt_mock,
-        requests_mock,
-    ):
-        test_jws_json_header = '{"kid":"test_kid","alg":"RS256"}'
-
-        post_json_mock = Mock(status_code=200)
-        post_json_mock.json.return_value = {
-            "id_token": "id_token",
-            "access_token": "access_granted",
-        }
-        requests_mock.post.return_value = post_json_mock
-        jws_mock.from_compact.return_value.signature.protected = test_jws_json_header
-
-        auth_request = RequestFactory().get("/foo", {"code": "foo", "state": "bar"})
-        with self.assertRaisesMessage(
-            SuspiciousOperation, "Could not find a valid JWKS."
-        ):
-            self.backend.authenticate(request=auth_request)
-
-    @patch("fecfiler.oidc.backends.requests")
-    @patch("fecfiler.oidc.backends.jwt")
-    @patch("fecfiler.oidc.backends.JWS")
-    def test_authenticate_verify_jws_failed_no_alg(
-        self,
-        jws_mock,
-        jwt_mock,
-        requests_mock,
-    ):
-        test_jws_json_header = '{"kid":"test_kid","alg":"RS256"}'
-        test_jwks = {"keys": [{"alg": "RS256", "kid": "test_kid"}]}
-
-        post_json_mock = Mock(status_code=200)
-        post_json_mock.json.return_value = {
-            "id_token": "id_token",
-            "access_token": "access_granted",
-        }
-
-        get_json_mock = Mock(status_code=200)
-        get_json_mock.json.return_value = test_jwks
-
-        requests_mock.post.return_value = post_json_mock
-        requests_mock.get.return_value = get_json_mock
-        jws_mock.from_compact.return_value.signature.protected = test_jws_json_header
-        jws_mock.from_compact.return_value.signature.combined = {}
-
-        auth_request = RequestFactory().get("/foo", {"code": "foo", "state": "bar"})
-        with self.assertRaisesMessage(
-            SuspiciousOperation, "No alg value found in header"
-        ):
-            self.backend.authenticate(request=auth_request)
-
-    @patch("fecfiler.oidc.backends.requests")
-    @patch("fecfiler.oidc.backends.jwt")
-    @patch("fecfiler.oidc.backends.JWS")
-    def test_authenticate_verify_jws_failed_alg_does_not_match(
-        self,
-        jws_mock,
-        jwt_mock,
-        requests_mock,
-    ):
-        test_jws_json_header = '{"kid":"test_kid","alg":"RS256"}'
-        test_jwks = {"keys": [{"alg": "RS256", "kid": "test_kid"}]}
-        test_alg = "invalid_alg_name"
-
-        post_json_mock = Mock(status_code=200)
-        post_json_mock.json.return_value = {
-            "id_token": "id_token",
-            "access_token": "access_granted",
-        }
-
-        get_json_mock = Mock(status_code=200)
-        get_json_mock.json.return_value = test_jwks
-
-        requests_mock.post.return_value = post_json_mock
-        requests_mock.get.return_value = get_json_mock
-        jws_mock.from_compact.return_value.signature.protected = test_jws_json_header
-        jws_mock.from_compact.return_value.signature.combined.alg.name = test_alg
-
-        auth_request = RequestFactory().get("/foo", {"code": "foo", "state": "bar"})
-        with self.assertRaisesMessage(
-            SuspiciousOperation,
-            "The provider algorithm {!r} does not match the client's "
-            "OIDC_RP_SIGN_ALGO.".format("invalid_alg_name"),
-        ):
-            self.backend.authenticate(request=auth_request)
-
-    @patch("fecfiler.oidc.backends.requests")
-    @patch("fecfiler.oidc.backends.jwt")
-    @patch("fecfiler.oidc.backends.JWS")
-    def test_authenticate_verify_jws_lib_call_failed(
-        self,
-        jws_mock,
-        jwt_mock,
-        requests_mock,
-    ):
-        test_jws_json_header = '{"kid":"test_kid","alg":"RS256"}'
-        test_jwks = {
-            "keys": [
-                {
-                    "alg": "RS256",
-                    "use": "sig",
-                    "kty": "RSA",
-                    "n": "test_n",
-                    "e": "test_e",
-                    "kid": "test_kid",
-                }
-            ]
-        }
-        test_alg = "RS256"
-
-        post_json_mock = Mock(status_code=200)
-        post_json_mock.json.return_value = {
-            "id_token": "id_token",
-            "access_token": "access_granted",
-        }
-
-        get_json_mock = Mock(status_code=200)
-        get_json_mock.json.return_value = test_jwks
-
-        requests_mock.post.return_value = post_json_mock
-        requests_mock.get.return_value = get_json_mock
-        jws_mock.from_compact.return_value.signature.protected = test_jws_json_header
-        jws_mock.from_compact.return_value.signature.combined.alg.name = test_alg
-        jws_mock.from_compact.return_value.verify.return_value = False
-
-        auth_request = RequestFactory().get("/foo", {"code": "foo", "state": "bar"})
-        with self.assertRaisesMessage(
-            SuspiciousOperation,
-            "JWS token verification failed",
-        ):
-            self.backend.authenticate(request=auth_request)
-
-    @patch("fecfiler.oidc.backends.requests")
-    @patch("fecfiler.oidc.backends.jwt")
-    @patch("fecfiler.oidc.backends.JWS")
+    @patch("fecfiler.oidc.backends.jws")
     def test_authenticate_nonce_verification_failed(
         self,
         jws_mock,
         jwt_mock,
+        jwk_mock,
         requests_mock,
     ):
-        test_jws_json_header = '{"kid":"test_kid","alg":"RS256"}'
-        test_jwks = {
-            "keys": [
-                {
-                    "alg": "RS256",
-                    "use": "sig",
-                    "kty": "RSA",
-                    "n": "test_n",
-                    "e": "test_e",
-                    "kid": "test_kid",
-                }
-            ]
-        }
-        test_alg = "RS256"
         test_jws_payload = b'{"nonce": "test_nonce_value"}'
 
         post_json_mock = Mock(status_code=200)
@@ -193,14 +43,10 @@ class OIDCAuthenticationBackendTestCase(TestCase):
         }
 
         get_json_mock = Mock(status_code=200)
-        get_json_mock.json.return_value = test_jwks
 
         requests_mock.post.return_value = post_json_mock
         requests_mock.get.return_value = get_json_mock
-        jws_mock.from_compact.return_value.signature.protected = test_jws_json_header
-        jws_mock.from_compact.return_value.signature.combined.alg.name = test_alg
-        jws_mock.from_compact.return_value.verify.return_value = True
-        jws_mock.from_compact.return_value.payload = test_jws_payload
+        jws_mock.JWS.return_value.payload = test_jws_payload
 
         auth_request = RequestFactory().get("/foo", {"code": "foo", "state": "bar"})
         with self.assertRaisesMessage(
@@ -212,78 +58,16 @@ class OIDCAuthenticationBackendTestCase(TestCase):
             )
 
     @patch("fecfiler.oidc.backends.requests")
+    @patch("fecfiler.oidc.backends.jwk")
     @patch("fecfiler.oidc.backends.jwt")
-    @patch("fecfiler.oidc.backends.JWS")
+    @patch("fecfiler.oidc.backends.jws")
     def test_authenticate_payload_claims_verification_failed(
         self,
         jws_mock,
         jwt_mock,
+        jwk_mock,
         requests_mock,
     ):
-        test_jws_json_header = '{"kid":"test_kid","alg":"RS256"}'
-        test_jwks = {
-            "keys": [
-                {
-                    "alg": "RS256",
-                    "use": "sig",
-                    "kty": "RSA",
-                    "n": "test_n",
-                    "e": "test_e",
-                    "kid": "test_kid",
-                }
-            ]
-        }
-        test_alg = "RS256"
-        test_jws_payload = b'{"nonce": "test_nonce_value"}'
-
-        post_json_mock = Mock(status_code=200)
-        post_json_mock.json.return_value = {
-            "id_token": "id_token",
-            "access_token": "access_granted",
-        }
-
-        get_json_mock = Mock(status_code=200)
-        get_json_mock.json.return_value = test_jwks
-
-        requests_mock.post.return_value = post_json_mock
-        requests_mock.get.return_value = get_json_mock
-        jws_mock.from_compact.return_value.signature.protected = test_jws_json_header
-        jws_mock.from_compact.return_value.signature.combined.alg.name = test_alg
-        jws_mock.from_compact.return_value.verify.return_value = True
-        jws_mock.from_compact.return_value.payload = test_jws_payload
-
-        auth_request = RequestFactory().get("/foo", {"code": "foo", "state": "bar"})
-        with self.assertRaisesMessage(
-            SuspiciousOperation,
-            "Claims verification failed",
-        ):
-            self.backend.authenticate(request=auth_request, nonce="test_nonce_value")
-
-    @patch("fecfiler.oidc.backends.requests")
-    @patch("fecfiler.oidc.backends.jwt")
-    @patch("fecfiler.oidc.backends.JWS")
-    @patch("fecfiler.oidc.backends.len")
-    def test_authenticate_oidc_op_unique_identifier_not_found(
-        self,
-        len_mock,
-        jws_mock,
-        jwt_mock,
-        requests_mock,
-    ):
-        test_jws_json_header = '{"kid":"test_kid","alg":"RS256"}'
-        test_jwks = {
-            "keys": [
-                {
-                    "alg": "RS256",
-                    "use": "sig",
-                    "kty": "RSA",
-                    "n": "test_n",
-                    "e": "test_e",
-                    "kid": "test_kid",
-                }
-            ]
-        }
-        test_alg = "RS256"
         test_jws_payload = b'{"nonce": "test_nonce_value"}'
 
         post_json_mock = Mock(status_code=200)
@@ -294,16 +78,49 @@ class OIDCAuthenticationBackendTestCase(TestCase):
 
         get_json_mock = Mock(status_code=200)
         get_json_mock.json.side_effect = [
-            test_jwks,
+            {"username": "test_username"},
+        ]
+
+        requests_mock.post.return_value = post_json_mock
+        requests_mock.get.return_value = get_json_mock
+        jws_mock.JWS.return_value.payload = test_jws_payload
+
+        auth_request = RequestFactory().get("/foo", {"code": "foo", "state": "bar"})
+        with self.assertRaisesMessage(
+            SuspiciousOperation,
+            "Claims verification failed",
+        ):
+            self.backend.authenticate(request=auth_request, nonce="test_nonce_value")
+
+    @patch("fecfiler.oidc.backends.requests")
+    @patch("fecfiler.oidc.backends.jwk")
+    @patch("fecfiler.oidc.backends.jwt")
+    @patch("fecfiler.oidc.backends.jws")
+    @patch("fecfiler.oidc.backends.len")
+    def test_authenticate_oidc_op_unique_identifier_not_found(
+        self,
+        len_mock,
+        jws_mock,
+        jwt_mock,
+        jwk_mock,
+        requests_mock,
+    ):
+        test_jws_payload = b'{"nonce": "test_nonce_value"}'
+
+        post_json_mock = Mock(status_code=200)
+        post_json_mock.json.return_value = {
+            "id_token": "id_token",
+            "access_token": "access_granted",
+        }
+
+        get_json_mock = Mock(status_code=200)
+        get_json_mock.json.side_effect = [
             {"email": "test_email", "username": "test_username"},
         ]
 
         requests_mock.post.return_value = post_json_mock
         requests_mock.get.return_value = get_json_mock
-        jws_mock.from_compact.return_value.signature.protected = test_jws_json_header
-        jws_mock.from_compact.return_value.signature.combined.alg.name = test_alg
-        jws_mock.from_compact.return_value.verify.return_value = True
-        jws_mock.from_compact.return_value.payload = test_jws_payload
+        jws_mock.JWS.return_value.payload = test_jws_payload
         len_mock.return_value = 2
 
         auth_request = RequestFactory().get("/foo", {"code": "foo", "state": "bar"})
@@ -314,30 +131,18 @@ class OIDCAuthenticationBackendTestCase(TestCase):
             self.backend.authenticate(request=auth_request, nonce="test_nonce_value")
 
     @patch("fecfiler.oidc.backends.requests")
+    @patch("fecfiler.oidc.backends.jwk")
     @patch("fecfiler.oidc.backends.jwt")
-    @patch("fecfiler.oidc.backends.JWS")
+    @patch("fecfiler.oidc.backends.jws")
     @patch("fecfiler.oidc.backends.len")
     def test_authenticate_payload_multiple_users_returned(
         self,
         len_mock,
         jws_mock,
         jwt_mock,
+        jwk_mock,
         requests_mock,
     ):
-        test_jws_json_header = '{"kid":"test_kid","alg":"RS256"}'
-        test_jwks = {
-            "keys": [
-                {
-                    "alg": "RS256",
-                    "use": "sig",
-                    "kty": "RSA",
-                    "n": "test_n",
-                    "e": "test_e",
-                    "kid": "test_kid",
-                }
-            ]
-        }
-        test_alg = "RS256"
         test_jws_payload = b'{"nonce": "test_nonce_value"}'
 
         post_json_mock = Mock(status_code=200)
@@ -348,16 +153,12 @@ class OIDCAuthenticationBackendTestCase(TestCase):
 
         get_json_mock = Mock(status_code=200)
         get_json_mock.json.side_effect = [
-            test_jwks,
             {"sub": "test_sub", "email": "test_email", "username": "test_username"},
         ]
 
         requests_mock.post.return_value = post_json_mock
         requests_mock.get.return_value = get_json_mock
-        jws_mock.from_compact.return_value.signature.protected = test_jws_json_header
-        jws_mock.from_compact.return_value.signature.combined.alg.name = test_alg
-        jws_mock.from_compact.return_value.verify.return_value = True
-        jws_mock.from_compact.return_value.payload = test_jws_payload
+        jws_mock.JWS.return_value.payload = test_jws_payload
         len_mock.return_value = 2
 
         auth_request = RequestFactory().get("/foo", {"code": "foo", "state": "bar"})
@@ -368,30 +169,18 @@ class OIDCAuthenticationBackendTestCase(TestCase):
             self.backend.authenticate(request=auth_request, nonce="test_nonce_value")
 
     @patch("fecfiler.oidc.backends.requests")
+    @patch("fecfiler.oidc.backends.jwk")
     @patch("fecfiler.oidc.backends.jwt")
-    @patch("fecfiler.oidc.backends.JWS")
+    @patch("fecfiler.oidc.backends.jws")
     @patch("fecfiler.oidc.backends.len")
     def test_authenticate_payload_create_new_user_happy_path(
         self,
         len_mock,
         jws_mock,
         jwt_mock,
+        jwk_mock,
         requests_mock,
     ):
-        test_jws_json_header = '{"kid":"test_kid","alg":"RS256"}'
-        test_jwks = {
-            "keys": [
-                {
-                    "alg": "RS256",
-                    "use": "sig",
-                    "kty": "RSA",
-                    "n": "test_n",
-                    "e": "test_e",
-                    "kid": "test_kid",
-                }
-            ]
-        }
-        test_alg = "RS256"
         test_jws_payload = b'{"nonce": "test_nonce_value"}'
 
         post_json_mock = Mock(status_code=200)
@@ -402,16 +191,12 @@ class OIDCAuthenticationBackendTestCase(TestCase):
 
         get_json_mock = Mock(status_code=200)
         get_json_mock.json.side_effect = [
-            test_jwks,
             {"sub": "test_sub", "email": "test_email", "username": "test_username"},
         ]
 
         requests_mock.post.return_value = post_json_mock
         requests_mock.get.return_value = get_json_mock
-        jws_mock.from_compact.return_value.signature.protected = test_jws_json_header
-        jws_mock.from_compact.return_value.signature.combined.alg.name = test_alg
-        jws_mock.from_compact.return_value.verify.return_value = True
-        jws_mock.from_compact.return_value.payload = test_jws_payload
+        jws_mock.JWS.return_value.payload = test_jws_payload
         len_mock.return_value = 0
 
         auth_request = RequestFactory().get("/foo", {"code": "foo", "state": "bar"})

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ django-otp==1.5.4
 zeep==4.2.1
 django-structlog[celery]==8.1.0
 rich==13.8.1
-josepy==1.14.0
 jwcrypto==1.5.6
 
 # Pinning sqlparse to 0.5.0 as it is a sub-dependency that needs to be upgraded for security


### PR DESCRIPTION
The approach chosen to remediating the snyk issue reported for josepy was to remove the josepy dependency altogether and replace it with jwcrypto.  This is beneficial because we just added the jwcrypto dependency to support our new mock_oidc_provider and also because jwcrypto is based on the cryptography package which is recommended over pyopenssl).  

This PR converts the josepy calls to the needed jwcrypto ones.  jwcrypto does more heavy lifting for us so some code could be removed as well.

https://fecgov.atlassian.net/browse/FECFILE-1634
 
