### PR TITLE
Feature/1639 updates

### DIFF
--- a/django-backend/fecfiler/committee_accounts/README.md
+++ b/django-backend/fecfiler/committee_accounts/README.md
@@ -1,7 +1,7 @@
 # Updating Committee Views in the Database
 
 When changes are made to the Committee Account model, it is necessary to update
-the Committee Views for each committee in the database.  To do this, create a new
+the Committee Views for each committee in the database. To do this, create a new
 migration in the Committee Account app and refer to the following boilerplate code:
 
 ```
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
 If `FLAG__COMMITTEE_DATA_SOURCE` is not set to `MOCKED`, everything will hit openfec normally
 
 Currently, the only backing is redis. Setting this to `MOCKED` will automatically
-configure `MOCK_OPENFEC_REDIS_URL` to the `REDIS_URL`
+use the redis instance at `MOCK_OPENFEC_REDIS_URL`
 `FLAG__COMMITTEE_DATA_SOURCE = "MOCKED"`
 
 # Local Development

--- a/django-backend/fecfiler/committee_accounts/management/commands/load_committee_data.py
+++ b/django-backend/fecfiler/committee_accounts/management/commands/load_committee_data.py
@@ -4,7 +4,6 @@ from fecfiler.settings import (
     MOCK_OPENFEC_REDIS_URL,
     BASE_DIR,
     AWS_STORAGE_BUCKET_NAME,
-    UNIT_TESTING_ENVIRONMENT
 )
 import redis
 import os
@@ -19,7 +18,7 @@ class Command(BaseCommand):
         parser.add_argument("--s3", action="store_true")
 
     def handle(self, *args, **options):
-        if FLAG__COMMITTEE_DATA_SOURCE == "MOCKED" or UNIT_TESTING_ENVIRONMENT:
+        if FLAG__COMMITTEE_DATA_SOURCE == "MOCKED":
             redis_instance = redis.Redis.from_url(MOCK_OPENFEC_REDIS_URL)
             if not options.get("s3"):
                 path = os.path.join(

--- a/django-backend/fecfiler/committee_accounts/test_views.py
+++ b/django-backend/fecfiler/committee_accounts/test_views.py
@@ -1,10 +1,7 @@
 from uuid import UUID
 from django.test import RequestFactory, TestCase
 from fecfiler.committee_accounts.models import Membership
-from fecfiler.committee_accounts.views import (
-    CommitteeMembershipViewSet,
-    CommitteeViewSet
-)
+from fecfiler.committee_accounts.views import CommitteeMembershipViewSet, CommitteeViewSet
 
 from fecfiler.user.models import User
 from unittest.mock import Mock, patch
@@ -157,85 +154,63 @@ class CommitteeViewSetTest(TestCase):
     def test_get_committee_account_data_from_production(self):
         with patch("fecfiler.committee_accounts.utils.settings") as settings:
             settings.FLAG__COMMITTEE_DATA_SOURCE = "PRODUCTION"
-            settings.FEC_API = "https://not-real.api/"
-            settings.FEC_API_KEY = "MOCK_KEY"
-            request = self.factory.get("/api/v1/committee_accounts/C12345678/committee/")
+            request = self.factory.get(
+                "/api/v1/committees/get-available-committee/?committee_id=C12345678"
+            )
             request.user = self.user
-            with patch("fecfiler.committee_accounts.utils.requests") as mock_requests:
-                mock_response = Mock()
-                mock_response.status_code = 200
-                mock_response.json.return_value = {}
-                mock_requests.get = Mock()
-                mock_requests.get.return_value = mock_response
+            request.query_params = {"committee_id": "C12345678"}
 
-                response = CommitteeViewSet.as_view({"get": "committee"})(
-                    request, pk="C12345678"
-                )
-                was_called_with = mock_requests.get.call_args.args
-                self.assertEqual(response.status_code, 200)
-                self.assertNotEqual(len(was_called_with), 0)
-                self.assertIn(
-                    "https://not-real.api/committee/C12345678/?api_key=MOCK_KEY",
-                    was_called_with
-                )
+            response = CommitteeViewSet.as_view({"get": "get_available_committee"})(
+                request
+            )
+            self.assertEqual(response.status_code, 500)
 
     def test_get_committee_account_data_from_test(self):
         with patch("fecfiler.committee_accounts.utils.settings") as settings:
             settings.FLAG__COMMITTEE_DATA_SOURCE = "TEST"
-            settings.FEC_API_STAGE = "https://stage.not-real.api/"
-            settings.FEC_API_KEY = "MOCK_KEY"
-            request = self.factory.get("/api/v1/committee_accounts/C12345678/committee/")
+            settings.STAGE_OPEN_FEC_API = "https://stage.not-real.api/"
+            settings.STAGE_OPEN_FEC_API_KEY = "MOCK_KEY"
+            request = self.factory.get(
+                "/api/v1/committees/get-available-committee/?committee_id=C12345678"
+            )
             request.user = self.user
+            request.query_params = {"committee_id": "C12345678"}
             with patch("fecfiler.committee_accounts.utils.requests") as mock_requests:
                 mock_response = Mock()
                 mock_response.status_code = 200
-                mock_response.json.return_value = {}
+                mock_response.json.return_value = {"results": [{"email": "test@fec.gov"}]}
                 mock_requests.get = Mock()
                 mock_requests.get.return_value = mock_response
 
-                response = CommitteeViewSet.as_view({"get": "committee"})(
-                    request, pk="C12345678"
+                response = CommitteeViewSet.as_view({"get": "get_available_committee"})(
+                    request
                 )
                 was_called_with = mock_requests.get.call_args.args
                 self.assertEqual(response.status_code, 200)
                 self.assertNotEqual(len(was_called_with), 0)
                 self.assertIn(
-                    "https://stage.not-real.api/efile/test-form1/",
-                    was_called_with
+                    "https://stage.not-real.api/efile/test-form1/", was_called_with
                 )
 
     def test_get_committee_account_data_from_redis(self):
         with patch("fecfiler.committee_accounts.utils.settings") as settings:
             settings.FLAG__COMMITTEE_DATA_SOURCE = "MOCKED"
-            request = self.factory.get("/api/v1/committee_accounts/C12345678/committee/")
+            request = self.factory.get(
+                "/api/v1/committees/get-available-committee/?committee_id=C12345678"
+            )
             request.user = self.user
+            request.query_params = {"committee_id": "C12345678"}
             with patch(
                 "fecfiler.committee_accounts.utils.get_committee_account_data_from_redis"
             ) as mock_committee:
                 mock_committee.return_value = {
-                    "name": "TEST"
+                    "committee_name": "TEST",
+                    "email": "test@fec.gov",
                 }
-                response = CommitteeViewSet.as_view({"get": "committee"})(
-                    request, pk="C12345678"
+                response = CommitteeViewSet.as_view({"get": "get_available_committee"})(
+                    request
                 )
                 was_called_with = mock_committee.call_args.args or []
                 self.assertNotEqual(len(was_called_with), 0)
-                self.assertIn(
-                    "C12345678",
-                    was_called_with
-                )
+                self.assertIn("C12345678", was_called_with)
                 self.assertEqual(response.data["name"], "TEST")
-
-    def test_get_committee_account_data_from_invalid(self):
-        with patch("fecfiler.committee_accounts.utils.settings") as settings:
-            settings.FLAG__COMMITTEE_DATA_SOURCE = "INVALID"
-            request = self.factory.get("/api/v1/committee_accounts/C12345678/committee/")
-            request.user = self.user
-
-            error = "FLAG__COMMITTEE_DATA_SOURCE improperly configured: INVALID"
-            response = CommitteeViewSet.as_view({"get": "committee"})(
-                request,
-                pk="C12345678"
-            )
-            self.assertEqual(response.status_code, 500)
-            self.assertEqual(response.content.decode(), error)

--- a/django-backend/fecfiler/committee_accounts/utils.py
+++ b/django-backend/fecfiler/committee_accounts/utils.py
@@ -139,7 +139,7 @@ def get_committee_account_data(committee_id):
             committee = get_committee_account_data_from_test_efo(committee_id)
         case "MOCKED":
             committee = get_committee_account_data_from_redis(committee_id)
-    if committee:
+    if committee and "committee_name" in committee:
         committee["name"] = committee.get("committee_name", None)
     return committee
 

--- a/django-backend/fecfiler/committee_accounts/views.py
+++ b/django-backend/fecfiler/committee_accounts/views.py
@@ -17,7 +17,7 @@ from django.db.models.fields import TextField
 from django.db.models.functions import Coalesce, Concat
 from django.db.models import Q, Value
 import structlog
-from django.http import HttpResponse, HttpResponseBadRequest
+from django.http import HttpResponse
 
 logger = structlog.get_logger(__name__)
 

--- a/django-backend/fecfiler/contacts/tests/test_views.py
+++ b/django-backend/fecfiler/contacts/tests/test_views.py
@@ -299,9 +299,7 @@ class ContactViewSetTest(TestCase):
         self.assertEqual(response.data, "")
 
     def test_get_committee_invalid(self):
-        request = self.factory.get(
-            "/api/v1/contacts/committee/"
-        )
+        request = self.factory.get("/api/v1/contacts/committee/")
         request.user = self.user
         request.session = {
             "committee_uuid": "11111111-2222-3333-4444-555555555555",
@@ -313,16 +311,14 @@ class ContactViewSetTest(TestCase):
 
     def test_get_committee(self):
         with patch("fecfiler.contacts.views.settings") as settings:
-            settings.FEC_API = "https://not-real.api/"
-            settings.FEC_API_KEY = "FAKE-KEY"
-            expected_call = 'https://not-real.api/committee/C12345678/?api_key=FAKE-KEY'
+            settings.PRODUCTION_OPEN_FEC_API = "https://not-real.api/"
+            settings.PRODUCTION_OPEN_FEC_API_KEY = "FAKE-KEY"
+            expected_call = "https://not-real.api/committee/C12345678/?api_key=FAKE-KEY"
             with patch("fecfiler.contacts.views.requests") as mock_requests:
                 mock_requests.get = Mock()
                 mock_response = Mock()
                 mock_response.json = Mock()
-                mock_response.json.return_value = {
-                    "results": [{"name": "TEST"}]
-                }
+                mock_response.json.return_value = {"results": [{"name": "TEST"}]}
                 mock_requests.get.return_value = mock_response
 
                 request = self.factory.get(

--- a/django-backend/fecfiler/contacts/views.py
+++ b/django-backend/fecfiler/contacts/views.py
@@ -110,7 +110,8 @@ class ContactViewSet(CommitteeOwnedViewMixin, viewsets.ModelViewSet):
 
         headers = {"Content-Type": "application/json"}
         response = requests.get(
-            f"{settings.PRODUCTION_OPEN_FEC_API}committee/{committee_id}/?api_key={settings.PRODUCTION_OPEN_FEC_API_KEY}",
+            f"{settings.PRODUCTION_OPEN_FEC_API}committee/{committee_id}/",
+            params={"api_key": settings.PRODUCTION_OPEN_FEC_API_KEY},
             headers=headers,
         ).json()
         if response.get("results"):

--- a/django-backend/fecfiler/contacts/views.py
+++ b/django-backend/fecfiler/contacts/views.py
@@ -28,6 +28,14 @@ NAME_REVERSED_CLAUSE = Concat(
     "last_name", Value(" "), "first_name", output_field=CharField()
 )
 
+FEC_API_COMMITTEE_LOOKUP_ENDPOINT = (
+    str(settings.PRODUCTION_OPEN_FEC_API) + "names/committees/"
+)
+FEC_API_CANDIDATE_LOOKUP_ENDPOINT = str(settings.PRODUCTION_OPEN_FEC_API) + "candidates/"
+FEC_API_CANDIDATE_ENDPOINT = (
+    str(settings.PRODUCTION_OPEN_FEC_API) + "candidate/{}/history/"
+)
+
 
 def validate_and_sanitize_candidate(candidate_id):
     if candidate_id is None:
@@ -82,10 +90,10 @@ class ContactViewSet(CommitteeOwnedViewMixin, viewsets.ModelViewSet):
         try:
             headers = {"Content-Type": "application/json"}
             params = {
-                "api_key": settings.FEC_API_KEY,
+                "api_key": settings.PRODUCTION_OPEN_FEC_API_KEY,
                 "sort": "-two_year_period",
             }
-            url = settings.FEC_API_CANDIDATE_ENDPOINT.format(
+            url = FEC_API_CANDIDATE_ENDPOINT.format(
                 validate_and_sanitize_candidate(candidate_id)
             )
             response = requests.get(url, headers=headers, params=params).json()
@@ -102,8 +110,8 @@ class ContactViewSet(CommitteeOwnedViewMixin, viewsets.ModelViewSet):
 
         headers = {"Content-Type": "application/json"}
         response = requests.get(
-            f"{settings.FEC_API}committee/{committee_id}/?api_key={settings.FEC_API_KEY}",
-            headers=headers
+            f"{settings.PRODUCTION_OPEN_FEC_API}committee/{committee_id}/?api_key={settings.PRODUCTION_OPEN_FEC_API_KEY}",
+            headers=headers,
         ).json()
         if response.get("results"):
             return JsonResponse(response["results"][0])
@@ -128,12 +136,12 @@ class ContactViewSet(CommitteeOwnedViewMixin, viewsets.ModelViewSet):
             if request.GET.get("exclude_ids")
             else []
         )
-        params = {"q": q, "api_key": settings.FEC_API_KEY}
+        params = {"q": q, "api_key": settings.PRODUCTION_OPEN_FEC_API_KEY}
         if office:
             params["office"] = office
         params = urlencode(params)
         json_results = requests.get(
-            settings.FEC_API_CANDIDATE_LOOKUP_ENDPOINT, params=params
+            FEC_API_CANDIDATE_LOOKUP_ENDPOINT, params=params
         ).json()
 
         tokens = list(filter(None, re.split("[^\\w+]", q)))
@@ -192,9 +200,9 @@ class ContactViewSet(CommitteeOwnedViewMixin, viewsets.ModelViewSet):
             if request.GET.get("exclude_ids")
             else []
         )
-        params = urlencode({"q": q, "api_key": settings.FEC_API_KEY})
+        params = urlencode({"q": q, "api_key": settings.PRODUCTION_OPEN_FEC_API_KEY})
         json_results = requests.get(
-            settings.FEC_API_COMMITTEE_LOOKUP_ENDPOINT, params=params
+            FEC_API_COMMITTEE_LOOKUP_ENDPOINT, params=params
         ).json()
 
         fecfile_committees = list(

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -381,7 +381,8 @@ FLAG__COMMITTEE_DATA_SOURCE = env.get_credential("FLAG__COMMITTEE_DATA_SOURCE")
 valid_sources = ["PRODUCTION", "TEST", "MOCKED"]
 if FLAG__COMMITTEE_DATA_SOURCE not in valid_sources:
     raise Exception(
-        f'FLAG__COMMITTEE_DATA_SOURCE "{FLAG__COMMITTEE_DATA_SOURCE}"must be valid source ({valid_sources})'
+        f'FLAG__COMMITTEE_DATA_SOURCE "{FLAG__COMMITTEE_DATA_SOURCE}"'
+        + f" must be valid source ({valid_sources})"
     )
 
 

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -342,10 +342,10 @@ CELERY_WORKER_STORAGE = env.get_credential("CELERY_WORKER_STORAGE", CeleryStorag
 
 """FEC Webload settings
 """
-MOCK_EFO_FILING = env.get_credential("MOCK_EFO_FILING", "False").lower() == "true"
+MOCK_EFO = env.get_credential("MOCK_EFO", "False").lower() == "true"
 FEC_FILING_API = env.get_credential("FEC_FILING_API")
-if not MOCK_EFO_FILING and FEC_FILING_API is None:
-    raise Exception("FEC_FILING_API must be set if MOCK_EFO_FILING is False")
+if not MOCK_EFO and FEC_FILING_API is None:
+    raise Exception("FEC_FILING_API must be set if MOCK_EFO is False")
 FEC_FILING_API_KEY = env.get_credential("FEC_FILING_API_KEY")
 FEC_AGENCY_ID = env.get_credential("FEC_AGENCY_ID")
 WEBPRINT_EMAIL = env.get_credential("WEBPRINT_EMAIL")
@@ -371,13 +371,6 @@ AWS_SECRET_ACCESS_KEY = env.get_credential("AWS_SECRET_ACCESS_KEY")
 AWS_STORAGE_BUCKET_NAME = env.get_credential("AWS_STORAGE_BUCKET_NAME")
 AWS_REGION = env.get_credential("AWS_REGION")
 
-"""FLAG_UNIT_TESTING_ENVIRONMENT
-If True, the API will set up certain features in anticipation of unit testing
-(e.g, `MOCK_OPENFEC_REDIS_URL` and `redis_instance`)
-"""
-UNIT_TESTING_ENVIRONMENT = env.get_credential(
-    "UNIT_TESTING_ENVIRONMENT", False
-)
 
 """FEATURE FLAGS
 """
@@ -385,27 +378,21 @@ UNIT_TESTING_ENVIRONMENT = env.get_credential(
 # FLAG__COMMITTEE_DATA_SOURCE:
 # Determines whether committee data is pulled from EFO, TestEFO, or REDIS
 FLAG__COMMITTEE_DATA_SOURCE = env.get_credential("FLAG__COMMITTEE_DATA_SOURCE")
-if FLAG__COMMITTEE_DATA_SOURCE not in ["PRODUCTION", "TEST", "MOCKED"]:
-    FLAG__COMMITTEE_DATA_SOURCE = "TEST"
+valid_sources = ["PRODUCTION", "TEST", "MOCKED"]
+if FLAG__COMMITTEE_DATA_SOURCE not in valid_sources:
+    raise Exception(
+        f'FLAG__COMMITTEE_DATA_SOURCE "{FLAG__COMMITTEE_DATA_SOURCE}"must be valid source ({valid_sources})'
+    )
 
 
-"""FEC API settings
-"""
-if FLAG__COMMITTEE_DATA_SOURCE == "PRODUCTION":
-    FEC_API = env.get_credential("FEC_API_PROD")
-else:
-    FEC_API = env.get_credential("FEC_API_TEST")
-FEC_API_STAGE = env.get_credential("FEC_API_TEST")
-FEC_API_KEY = env.get_credential("FEC_API_KEY")
-FEC_API_COMMITTEE_LOOKUP_ENDPOINT = str(FEC_API) + "names/committees/"
-FEC_API_CANDIDATE_LOOKUP_ENDPOINT = str(FEC_API) + "candidates/"
-FEC_API_CANDIDATE_ENDPOINT = str(FEC_API) + "candidate/{}/history/"
+PRODUCTION_OPEN_FEC_API = env.get_credential("PRODUCTION_OPEN_FEC_API")
+PRODUCTION_OPEN_FEC_API_KEY = env.get_credential("PRODUCTION_OPEN_FEC_API_KEY")
 
+STAGE_OPEN_FEC_API = env.get_credential("STAGE_OPEN_FEC_API")
+STAGE_OPEN_FEC_API_KEY = env.get_credential("STAGE_OPEN_FEC_API_KEY")
 
 """MOCK OPENFEC settings"""
-MOCK_OPENFEC_REDIS_URL = None
-if FLAG__COMMITTEE_DATA_SOURCE == "MOCKED" or UNIT_TESTING_ENVIRONMENT:
-    MOCK_OPENFEC_REDIS_URL = env.get_credential("REDIS_URL")
+MOCK_OPENFEC_REDIS_URL = env.get_credential("REDIS_URL")
 
 CREATE_COMMITTEE_ACCOUNT_ALLOWED_EMAIL_LIST = env.get_credential(
     "CREATE_COMMITTEE_ACCOUNT_ALLOWED_EMAIL_LIST", []

--- a/django-backend/fecfiler/web_services/views.py
+++ b/django-backend/fecfiler/web_services/views.py
@@ -10,7 +10,7 @@ from fecfiler.web_services.tasks import (
     submit_to_webprint,
 )
 from fecfiler.web_services.summary.tasks import CalculationState, calculate_summary
-from fecfiler.settings import MOCK_EFO_FILING
+from fecfiler.settings import MOCK_EFO
 from .serializers import ReportIdSerializer, SubmissionRequestSerializer
 from .renderers import DotFECRenderer
 from .web_service_storage import get_file
@@ -104,7 +104,7 @@ class WebServicesViewSet(viewsets.ViewSet):
 
         """Retrieve parameters"""
         mock = request.query_params.get("mock", "false").lower() == "true"
-        if MOCK_EFO_FILING:
+        if MOCK_EFO:
             """If the server is set to mock, all submissions will be mocked"""
             mock = True
         report_id = serializer.validated_data["report_id"]
@@ -151,7 +151,7 @@ class WebServicesViewSet(viewsets.ViewSet):
 
         """Retrieve parameters"""
         mock = request.query_params.get("mock", "false").lower() == "true"
-        if MOCK_EFO_FILING:
+        if MOCK_EFO:
             """If the server is set to mock, all submissions will be mocked"""
             mock = True
         report_id = serializer.validated_data["report_id"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,12 +52,14 @@ services:
             AWS_STORAGE_BUCKET_NAME:
             AWS_REGION:
             CELERY_WORKER_STORAGE:
+            MOCK_EFO: True
             FEC_FILING_API:
             FEC_FILING_API_KEY:
             FEC_AGENCY_ID:
             WEBPRINT_EMAIL:
             OUTPUT_TEST_INFO_IN_DOT_FEC:
             LOG_FORMAT:
+            FLAG__COMMITTEE_DATA_SOURCE: MOCKED # Values are PRODUCTION, TEST, and MOCKED
         deploy:
             resources:
                 limits:
@@ -97,24 +99,25 @@ services:
             AWS_STORAGE_BUCKET_NAME:
             AWS_REGION:
             CELERY_WORKER_STORAGE:
+            MOCK_EFO: True
             FEC_FILING_API:
             FEC_FILING_API_KEY:
             FEC_AGENCY_ID:
             WEBPRINT_EMAIL:
             OUTPUT_TEST_INFO_IN_DOT_FEC:
-            FEC_API_PROD: https://api.open.fec.gov/v1/
-            FEC_API_TEST: https://api-stage.open.fec.gov/v1/
-            FEC_API_KEY:
+            PRODUCTION_OPEN_FEC_API: https://api.open.fec.gov/v1/
+            PRODUCTION_OPEN_FEC_API_KEY: DEMO_KEY
+            STAGE_OPEN_FEC_API: https://api-stage.open.fec.gov/v1/
+            STAGE_OPEN_FEC_API_KEY: DEMO_KEY
             LOG_FORMAT:
             FECFILE_GITHUB_TOKEN:
             OIDC_OP_AUTODISCOVER_ENDPOINT: http://localhost:8080/api/v1/mock_oidc_provider/.well-known/openid-configuration
-            MOCK_EFO_FILING: REDIS
             EFO_POLLING_MAX_DURATION: 300
             EFO_POLLING_INTERVAL: 30
             CREATE_COMMITTEE_ACCOUNT_ALLOWED_EMAIL_LIST:
-            UNIT_TESTING_ENVIRONMENT: True # True for environments where running unit tests is expected
+
             # ---- FEATURE FLAGS ----
-            FLAG__COMMITTEE_DATA_SOURCE: TEST # Values are PRODUCTION, TEST, and MOCKED, defaults to TEST
+            FLAG__COMMITTEE_DATA_SOURCE: MOCKED # Values are PRODUCTION, TEST, and MOCKED
         deploy:
             resources:
                 limits:
@@ -141,18 +144,19 @@ services:
         volumes:
             - ./:/mnt/locust
         command: -f /mnt/locust/performance-testing/locust_run.py --master -H http://fecfile-api:8080
-        profiles: [locust]
+        profiles: [ locust ]
         environment:
             LOCAL_TEST_USER:
             LOCAL_TEST_PWD:
             OIDC_SESSION_ID:
+
 
     locust-follower:
         image: locustio/locust
         volumes:
             - ./:/mnt/locust
         command: -f /mnt/locust/performance-testing/locust_run.py --worker --master-host locust-leader -L DEBUG
-        profiles: [locust]
+        profiles: [ locust ]
         environment:
             LOCAL_TEST_USER:
             LOCAL_TEST_PWD:

--- a/manifests/manifest-dev-api.yml
+++ b/manifests/manifest-dev-api.yml
@@ -21,15 +21,14 @@ applications:
       LOGIN_REDIRECT_CLIENT_URL: https://dev.fecfile.fec.gov
       LOGIN_REDIRECT_SERVER_URL: https://dev-api.fecfile.fec.gov/api/v1/oidc/login-redirect
       LOGOUT_REDIRECT_URL: https://dev-api.fecfile.fec.gov/api/v1/oidc/logout-redirect
-      FEC_API_PROD: https://api.open.fec.gov/v1/
-      FEC_API_TEST: https://api-stage.open.fec.gov/v1/
+      PRODUCTION_OPEN_FEC_API: https://api.open.fec.gov/v1/
+      STAGE_OPEN_FEC_API: https://api-stage.open.fec.gov/v1/
+      FEC_FILING_API: https://efoservices.stage.efo.fec.gov
       SESSION_COOKIE_AGE: 64800
       BP_PIP_VERSION: latest
       LOG_FORMAT: KEY_VALUE
       SYSTEM_STATUS_CACHE_AGE: 60
-      MOCK_EFO_FILING: REDIS
       EFO_POLLING_MAX_DURATION: 300
       EFO_POLLING_INTERVAL: 30
-      UNIT_TESTING_ENVIRONMENT: False # True for environments where running unit tests is expected
       # ---- FEATURE FLAGS ----
-      FLAG__COMMITTEE_DATA_SOURCE: TEST # Values are PRODUCTION, TEST, MOCKED, defaults to TEST
+      FLAG__COMMITTEE_DATA_SOURCE: TEST # Values are PRODUCTION, TEST, MOCKED

--- a/manifests/manifest-prod-api.yml
+++ b/manifests/manifest-prod-api.yml
@@ -21,15 +21,14 @@ applications:
       LOGIN_REDIRECT_CLIENT_URL: https://fecfile.fec.gov
       LOGIN_REDIRECT_SERVER_URL: https://api.fecfile.fec.gov/api/v1/oidc/login-redirect
       LOGOUT_REDIRECT_URL: https://api.fecfile.fec.gov/api/v1/oidc/logout-redirect
-      FEC_API_PROD: https://api.open.fec.gov/v1/
-      FEC_API_TEST: https://api-stage.open.fec.gov/v1/
+      PRODUCTION_OPEN_FEC_API: https://api.open.fec.gov/v1/
+      STAGE_OPEN_FEC_API: https://api-stage.open.fec.gov/v1/
+      FEC_FILING_API: https://efoservices.stage.efo.fec.gov
       SESSION_COOKIE_AGE: 64800
       BP_PIP_VERSION: latest
       LOG_FORMAT: KEY_VALUE
       SYSTEM_STATUS_CACHE_AGE: 60
-      MOCK_EFO_FILING: REDIS
-      UNIT_TESTING_ENVIRONMENT: False # True for environments where running unit tests is expected
       EFO_POLLING_MAX_DURATION: 300
       EFO_POLLING_INTERVAL: 30
       # ---- FEATURE FLAGS ----
-      FLAG__COMMITTEE_DATA_SOURCE: PRODUCTION # Values are PRODUCTION, TEST, and MOCKED, defaults to TEST
+      FLAG__COMMITTEE_DATA_SOURCE: PRODUCTION # Values are PRODUCTION, TEST, and MOCKED

--- a/manifests/manifest-stage-api.yml
+++ b/manifests/manifest-stage-api.yml
@@ -21,15 +21,14 @@ applications:
       LOGIN_REDIRECT_CLIENT_URL: https://stage.fecfile.fec.gov
       LOGIN_REDIRECT_SERVER_URL: https://stage-api.fecfile.fec.gov/api/v1/oidc/login-redirect
       LOGOUT_REDIRECT_URL: https://stage-api.fecfile.fec.gov/api/v1/oidc/logout-redirect
-      FEC_API_PROD: https://api.open.fec.gov/v1/
-      FEC_API_TEST: https://api-stage.open.fec.gov/v1/
+      PRODUCTION_OPEN_FEC_API: https://api.open.fec.gov/v1/
+      STAGE_OPEN_FEC_API: https://api-stage.open.fec.gov/v1/
+      FEC_FILING_API: https://efoservices.stage.efo.fec.gov
       SESSION_COOKIE_AGE: 64800
       BP_PIP_VERSION: latest
       LOG_FORMAT: KEY_VALUE
       SYSTEM_STATUS_CACHE_AGE: 60
-      MOCK_EFO_FILING: REDIS
-      UNIT_TESTING_ENVIRONMENT: False # True for environments where running unit tests is expected
       EFO_POLLING_MAX_DURATION: 300
       EFO_POLLING_INTERVAL: 30
       # ---- FEATURE FLAGS ----
-      FLAG__COMMITTEE_DATA_SOURCE: TEST # Values are TEST and PRODUCTION, defaults to TEST
+      FLAG__COMMITTEE_DATA_SOURCE: TEST # Values are TEST and PRODUCTION

--- a/manifests/manifest-test-api.yml
+++ b/manifests/manifest-test-api.yml
@@ -21,15 +21,14 @@ applications:
       LOGIN_REDIRECT_CLIENT_URL: https://test.fecfile.fec.gov
       LOGIN_REDIRECT_SERVER_URL: https://test-api.fecfile.fec.gov/api/v1/oidc/login-redirect
       LOGOUT_REDIRECT_URL: https://test-api.fecfile.fec.gov/api/v1/oidc/logout-redirect
-      FEC_API_PROD: https://api.open.fec.gov/v1/
-      FEC_API_TEST: https://api-stage.open.fec.gov/v1/
+      PRODUCTION_OPEN_FEC_API: https://api.open.fec.gov/v1/
+      STAGE_OPEN_FEC_API: https://api-stage.open.fec.gov/v1/
+      FEC_FILING_API: https://efoservices.stage.efo.fec.gov
       SESSION_COOKIE_AGE: 64800
       BP_PIP_VERSION: latest
       LOG_FORMAT: KEY_VALUE
       SYSTEM_STATUS_CACHE_AGE: 60
-      MOCK_EFO_FILING: REDIS
-      UNIT_TESTING_ENVIRONMENT: False # True for environments where running unit tests is expected
       EFO_POLLING_MAX_DURATION: 300
       EFO_POLLING_INTERVAL: 30
       # ---- FEATURE FLAGS ----
-      FLAG__COMMITTEE_DATA_SOURCE: TEST # Values are PRODUCTION, TEST, and MOCKED, defaults to TEST
+      FLAG__COMMITTEE_DATA_SOURCE: TEST # Values are PRODUCTION, TEST, and MOCKED


### PR DESCRIPTION
 - added committee data enrichment to the commmittee account list
- changed get_committee_account_data_from_X to return a committee dict
- changes open fec url settings to use different keys between apis
- replaced generic committee retreive with get_available_committee
- fixed 'MOCK_EFO_FILING: REDIS' bug
- removed changes to EFO filing to avoid touching downstream features
- simplified redis url settings for mock data

## Summary

- Issue api#<number> and/or app#<number>
  
(Include a summary of proposed changes)

## How to test

(Include any information that may be helpful to the reviewer(s). This might include links to sample pages to test or any local environmental setup that is unusual such as environment variable (never credentials), API version to point to, etc)

- 
