### PR TITLE
feature/1763 - Update blocking_reports to use list instead of list()

### DIFF
--- a/django-backend/fecfiler/transactions/migrations/0012_alter_transactions_blocking_reports.py
+++ b/django-backend/fecfiler/transactions/migrations/0012_alter_transactions_blocking_reports.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+from django.contrib.postgres.fields import ArrayField
+
+
+def update_blocking_reports_default(apps, schema_editor):
+    transaction = apps.get_model("transactions", "Transaction")
+    transaction._meta.get_field("blocking_reports").default = list
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("transactions", "0011_transaction_can_delete"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="transaction",
+            name="blocking_reports",
+            field=ArrayField(
+                base_field=models.UUIDField(),
+                blank=False,
+                default=list,
+                size=None,
+            ),
+        ),
+        migrations.RunPython(update_blocking_reports_default),
+    ]

--- a/django-backend/fecfiler/transactions/models.py
+++ b/django-backend/fecfiler/transactions/models.py
@@ -149,7 +149,7 @@ class Transaction(SoftDeleteModel, CommitteeOwnedModel):
     )
     # report ids of reports that have been submitted
     # and in doing so have blocked this transaction from being deleted
-    blocking_reports = ArrayField(models.UUIDField(), blank=False, default=list())
+    blocking_reports = ArrayField(models.UUIDField(), blank=False, default=list)
 
     objects = TransactionManager()
 


### PR DESCRIPTION
Issue [FECFILE-1763](https://fecgov.atlassian.net/browse/FECFILE-1763)

Note that this and [PR1165](https://github.com/fecgov/fecfile-web-api/pull/1165) both include migrations so there will be a conflict.