### PR TITLE
Modify run command - only instance 0 runs migrations/creates views

### DIFF
--- a/bin/run-api.sh
+++ b/bin/run-api.sh
@@ -1,6 +1,13 @@
 cd django-backend
 
-# Run migrations and application
-./manage.py migrate --no-input --traceback --verbosity 3 &&
-	python manage.py create_committee_views &&
-	exec gunicorn --bind 0.0.0.0:8080 fecfiler.wsgi -w 9
+# Only Instance 0 runs migrations and creates views
+echo "------ Starting APP ------"
+if [ $CF_INSTANCE_INDEX = "0" ]; then
+    echo "----- Migrating Database -----"
+    python manage.py migrate --no-input --traceback --verbosity 3
+    echo "----- Creating committee views -----"
+    python manage.py create_committee_views
+fi
+
+# Run application
+exec gunicorn --bind 0.0.0.0:8080 fecfiler.wsgi -w 9


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-1773 and https://fecgov.atlassian.net/browse/FECFILE-1794

Reference: https://cloud.gov/docs/management/multiple-instances/
  
Tested with manual deploy: https://app.circleci.com/pipelines/github/fecgov/fecfile-web-api/4569/workflows/bbef3efe-b610-4f34-8380-71746cf1dd72/jobs/13167

Verified in logs (was running twice together, now once per deploy):
<img width="1411" alt="Screenshot 2024-11-14 at 3 46 13 PM" src="https://github.com/user-attachments/assets/cffbebb1-4cd6-42b6-88da-e21cddc45dba">

