### PR TITLE
Feature/1766 fail build for missing migrations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,13 @@ jobs:
           working_directory: ~/project/db
 
       - run:
-          name: Create/run migrations
+          name: Check migrations
+          command: |
+            python manage.py makemigrations --check
+          working_directory: ~/project/django-backend/
+
+      - run:
+          name: Run migrations
           command: |
             python manage.py migrate --no-input --traceback --verbosity 3
           working_directory: ~/project/django-backend/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,12 +64,6 @@ jobs:
             python manage.py migrate --no-input --traceback --verbosity 3
           working_directory: ~/project/django-backend/
 
-      # Only use SonarCloud security checking for now.
-      #      - run:
-      #          name: Bandit security checks
-      #          command: |
-      #            bandit -f json --output bandit.out  -ii -ll -r . || echo "Bandit found issues" && cat bandit.out
-
       - run:
           name: Run tests
           # Use built-in Django test module


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-1766
  
Related PRs: None

Django docs on `makemigrations --check`: https://docs.djangoproject.com/en/5.1/ref/django-admin/#cmdoption-makemigrations-check

Example catching missing migrations: https://app.circleci.com/pipelines/github/fecgov/fecfile-web-api/4534/workflows/c68f2886-3936-4f88-b20b-3ed596302f46/jobs/13097

```python manage.py makemigrations --check```
```
System check identified some issues:

WARNINGS:
?: (staticfiles.W004) The directory '/home/circleci/project/django-backend/fecfiler/staticfiles' in the STATICFILES_DIRS setting does not exist.
transactions.Transaction.blocking_reports: (fields.E010) ArrayField default should be a callable instead of an instance so that it's not shared between all field instances.
        HINT: Use a callable instead, e.g., use `list` instead of `[]`.
Migrations for 'cash_on_hand':
  fecfiler/cash_on_hand/migrations/0002_alter_cashonhandyearly_cash_on_hand_and_more.py
    ~ Alter field cash_on_hand on cashonhandyearly
    ~ Alter field year on cashonhandyearly

Exited with code exit status 1
```