### PR TITLE
feature/1784 - Fix oidc callback redirect to go to login redirect as opposed to '/' which was previously redirecting to login

### DIFF
--- a/django-backend/fecfiler/oidc/views.py
+++ b/django-backend/fecfiler/oidc/views.py
@@ -108,7 +108,7 @@ def oidc_callback(request):
             handle_oidc_callback_request(request)
             return HttpResponseRedirect(LOGIN_REDIRECT_URL)
         handle_oidc_callback_error(request)
-        return HttpResponseRedirect("/")
+        return HttpResponseRedirect(LOGIN_REDIRECT_CLIENT_URL)
     except Exception as error:
         logger.error(f"Failed to process oidc_callback request {str(error)}")
         return HttpResponseServerError()


### PR DESCRIPTION
Issue [FECFILE-1784](https://fecgov.atlassian.net/browse/FECFILE-1784)