### PR TITLE
(Patch) Move basic config to docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ To integrate with EFO, set the following environment variables:
 ```
 # Test EFO Services (for test filings):
 export MOCK_EFO_FILING=False
-export EFO_FILING_API="EFO_get_this_from_team_member"
 export EFO_FILING_API_KEY="EFO_get_this_from_team_member"
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,20 +32,7 @@ When running docker-compose you will need to be in the root directory of the pro
 
 `docker-compose up -d`
 
-You should set the following environment variables in the shell where you are running 'docker-compose up -d'.
-Proper values for the development variables are shown here as an example
-
-```
-export DATABASE_URL="postgres://postgres:postgres@db/postgres"
-export FECFILE_TEST_DB_NAME="postgres"
-export DJANGO_SECRET_KEY="If_using_test_db_use_secret_key_in_cloud.gov"
-export FEC_API="https://api.open.fec.gov/v1/"
-# Note - this API key has a very low rate limit -
-# For a better key, reach out to a team member or get one at https://api.open.fec.gov/developers/
-export FEC_API_KEY="DEMO_KEY"
-```
-
-By default EFO services will be mocked
+By default EFO services (print/upload) will be mocked.
 To integrate with EFO, set the following environment variables:
 
 ```
@@ -54,6 +41,9 @@ export MOCK_EFO_FILING=False
 export EFO_FILING_API="EFO_get_this_from_team_member"
 export EFO_FILING_API_KEY="EFO_get_this_from_team_member"
 ```
+
+*Note* - the default PRODUCTION_OPEN_FEC_API_KEY and STAGE_OPEN_FEC_API_KEY key has a very low rate limit -
+for a better key, reach out to a team member or get one at https://api.open.fec.gov/developers/
 
 ### Shut down the containers
 

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -344,9 +344,12 @@ CELERY_BEAT_SCHEDULE = {
 """
 MOCK_EFO_FILING = get_boolean_from_string(env.get_credential("MOCK_EFO_FILING", "False"))
 EFO_FILING_API = env.get_credential("EFO_FILING_API")
-if not MOCK_EFO_FILING and EFO_FILING_API is None:
-    raise Exception("EFO_FILING_API must be set if MOCK_EFO_FILING is False")
 EFO_FILING_API_KEY = env.get_credential("EFO_FILING_API_KEY")
+if not MOCK_EFO_FILING:
+    if EFO_FILING_API is None:
+        raise Exception("EFO_FILING_API must be set if MOCK_EFO_FILING is False")
+    if EFO_FILING_API_KEY is None:
+        raise Exception("EFO_FILING_API_KEY must be set if MOCK_EFO_FILING is False")
 FEC_AGENCY_ID = env.get_credential("FEC_AGENCY_ID")
 
 """EFO POLLING SETTINGS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,7 @@ services:
       AWS_REGION:
       CELERY_WORKER_STORAGE:
       MOCK_EFO_FILING: True
-      EFO_FILING_API:
+      EFO_FILING_API: https://efoservices.stage.efo.fec.gov
       EFO_FILING_API_KEY:
       FEC_AGENCY_ID:
       OUTPUT_TEST_INFO_IN_DOT_FEC:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,8 @@ services:
       - redis
     environment:
       REDIS_URL: redis://redis:6379
-      DATABASE_URL:
-      FECFILE_TEST_DB_NAME:
+      DATABASE_URL: postgres://postgres:postgres@db/postgres
+      FECFILE_TEST_DB_NAME: postgres
       DJANGO_SETTINGS_MODULE: fecfiler.settings.local
       DJANGO_SECRET_KEY:
       FECFILE_FEC_WEBSITE_API_KEY: DEMO_KEY
@@ -53,7 +53,7 @@ services:
       AWS_REGION:
       CELERY_WORKER_STORAGE:
       MOCK_EFO_FILING: True
-      EFO_FILING_API:
+      EFO_FILING_API: https://efoservices.stage.efo.fec.gov
       EFO_FILING_API_KEY:
       FEC_AGENCY_ID:
       OUTPUT_TEST_INFO_IN_DOT_FEC:
@@ -83,8 +83,8 @@ services:
       - redis
     environment:
       REDIS_URL: redis://redis:6379
-      DATABASE_URL:
-      FECFILE_TEST_DB_NAME:
+      DATABASE_URL: postgres://postgres:postgres@db/postgres
+      FECFILE_TEST_DB_NAME: postgres
       DJANGO_SETTINGS_MODULE: fecfiler.settings.local
       DJANGO_SECRET_KEY:
       FECFILE_FEC_WEBSITE_API_KEY: DEMO_KEY
@@ -123,8 +123,8 @@ services:
       - redis
     environment:
       REDIS_URL: redis://redis:6379
-      DATABASE_URL:
-      FECFILE_TEST_DB_NAME:
+      DATABASE_URL: postgres://postgres:postgres@db/postgres
+      FECFILE_TEST_DB_NAME: postgres
       DJANGO_SETTINGS_MODULE: fecfiler.settings.local
       DJANGO_SECRET_KEY:
       FECFILE_FEC_WEBSITE_API_KEY: DEMO_KEY
@@ -141,7 +141,7 @@ services:
       AWS_REGION:
       CELERY_WORKER_STORAGE:
       MOCK_EFO_FILING: True
-      EFO_FILING_API:
+      EFO_FILING_API: https://efoservices.stage.efo.fec.gov
       EFO_FILING_API_KEY:
       FEC_AGENCY_ID:
       OUTPUT_TEST_INFO_IN_DOT_FEC:


### PR DESCRIPTION
Ticket link: N/A
  
- Move more basic config to docker compose
- Add exception for missing `EFO_FILING_API_KEY`
- Update README