### PR TITLE
FECFILE-2070: Added option to disable by UUID.

### DIFF
--- a/django-backend/fecfiler/user/management/commands/disable_user.py
+++ b/django-backend/fecfiler/user/management/commands/disable_user.py
@@ -32,6 +32,6 @@ class Command(BaseCommand):
         user.save()
 
         self.stdout.write(self.style.SUCCESS(
-            f'The is_active flag for user [{user.username} | {user.email}] ' +
+            f'The is_active flag for user [{user.username} | {user.email}] '
             f'set to: {user.is_active}'
         ))

--- a/django-backend/fecfiler/user/management/commands/disable_user.py
+++ b/django-backend/fecfiler/user/management/commands/disable_user.py
@@ -6,7 +6,11 @@ class Command(BaseCommand):
     help = 'Disable (or re-enable) a user with a given email.'
 
     def add_arguments(self, parser):
-        parser.add_argument('email', type=str,
+        # require either a UUID or email
+        id_arg = parser.add_mutually_exclusive_group(required=True)
+        id_arg.add_argument('--uuid', type=str,
+                help='The UUID of the user to be disabled/enabled.')
+        id_arg.add_argument('--email', type=str,
                 help='The email address of the user to be disabled/enabled.')
         # add an --enable flag that defaults to false if not found
         parser.add_argument('-e', '--enable', action='store_true',
@@ -16,7 +20,11 @@ class Command(BaseCommand):
         user_model = get_user_model()
 
         try:
-            user = user_model.objects.get(email=options['email'])
+            # if they use both arguments, prefer UUID
+            if options['uuid'] is not None:
+                user = user_model.objects.get(username=options['uuid'])
+            else:
+                user = user_model.objects.get(email=options['email'])
         except user_model.DoesNotExist:
             raise CommandError('User does not exist')
 
@@ -24,5 +32,5 @@ class Command(BaseCommand):
         user.save()
 
         self.stdout.write(self.style.SUCCESS(
-            f'The is_active flag for user [{user.email}] set to: {user.is_active}'
+            f'The is_active flag for user [{user.username} | {user.email}] set to: {user.is_active}'
         ))

--- a/django-backend/fecfiler/user/management/commands/disable_user.py
+++ b/django-backend/fecfiler/user/management/commands/disable_user.py
@@ -32,5 +32,6 @@ class Command(BaseCommand):
         user.save()
 
         self.stdout.write(self.style.SUCCESS(
-            f'The is_active flag for user [{user.username} | {user.email}] set to: {user.is_active}'
+            f'The is_active flag for user [{user.username} | {user.email}] ' +
+            f'set to: {user.is_active}'
         ))

--- a/django-backend/fecfiler/user/management/commands/disable_user.py
+++ b/django-backend/fecfiler/user/management/commands/disable_user.py
@@ -22,7 +22,7 @@ class Command(BaseCommand):
         try:
             # if they use both arguments, prefer UUID
             if options['uuid'] is not None:
-                user = user_model.objects.get(username=options['uuid'])
+                user = user_model.objects.get(id=options['uuid'])
             else:
                 user = user_model.objects.get(email=options['email'])
         except user_model.DoesNotExist:
@@ -32,6 +32,6 @@ class Command(BaseCommand):
         user.save()
 
         self.stdout.write(self.style.SUCCESS(
-            f'The is_active flag for user [{user.username} | {user.email}] '
+            f'The is_active flag for user [{user.id} | {user.email}] '
             f'set to: {user.is_active}'
         ))

--- a/django-backend/fecfiler/user/test_disable_user_command.py
+++ b/django-backend/fecfiler/user/test_disable_user_command.py
@@ -7,7 +7,8 @@ from django.contrib.auth import get_user_model
 class DisableUserCommandTest(TestCase):
 
     def setUp(self):
-        self.test_user = User.objects.create(id="fec10000-70dd-1335-aaaa-d4d10fecf113", email="test@fec.gov", username="gov")
+        self.test_user = User.objects.create(id="fec10000-70dd-1335-aaaa-d4d10fecf113",
+                                             email="test@fec.gov", username="gov")
 
     def test_disable_user_email(self):
         user_model = get_user_model()

--- a/django-backend/fecfiler/user/test_disable_user_command.py
+++ b/django-backend/fecfiler/user/test_disable_user_command.py
@@ -9,7 +9,7 @@ class DisableUserCommandTest(TestCase):
     def setUp(self):
         self.test_user = User.objects.create(email="test@fec.gov", username="gov")
 
-    def test_disable_user(self):
+    def test_disable_user_email(self):
         user_model = get_user_model()
 
         # get the test user
@@ -18,10 +18,27 @@ class DisableUserCommandTest(TestCase):
 
         # disable the test user
         try:
-            call_command("disable_user", user.email)
+            call_command("disable_user", email=user.email)
         except Exception as e:
             print(f"Error running command: {e}")
 
         # re-get the test user
         user = user_model.objects.get(email=self.test_user.email)
+        self.assertFalse(user.is_active)
+
+    def test_disable_user_uuid(self):
+        user_model = get_user_model()
+
+        # get the test user
+        user = user_model.objects.get(username=self.test_user.username)
+        self.assertTrue(user.is_active)
+
+        # disable the test user
+        try:
+            call_command("disable_user", uuid=user.username)
+        except Exception as e:
+            print(f"Error running command: {e}")
+
+        # re-get the test user
+        user = user_model.objects.get(username=self.test_user.username)
         self.assertFalse(user.is_active)

--- a/django-backend/fecfiler/user/test_disable_user_command.py
+++ b/django-backend/fecfiler/user/test_disable_user_command.py
@@ -29,13 +29,13 @@ class DisableUserCommandTest(TestCase):
     def test_disable_user_uuid(self):
         user_model = get_user_model()
 
-        # get the test user
+        # get the test user by username
         user = user_model.objects.get(username=self.test_user.username)
         self.assertTrue(user.is_active)
 
-        # disable the test user
+        # disable the test user by id
         try:
-            call_command("disable_user", uuid=user.username)
+            call_command("disable_user", uuid=user.id)
         except Exception as e:
             print(f"Error running command: {e}")
 

--- a/django-backend/fecfiler/user/test_disable_user_command.py
+++ b/django-backend/fecfiler/user/test_disable_user_command.py
@@ -7,7 +7,7 @@ from django.contrib.auth import get_user_model
 class DisableUserCommandTest(TestCase):
 
     def setUp(self):
-        self.test_user = User.objects.create(email="test@fec.gov", username="gov")
+        self.test_user = User.objects.create(id="fec10000-70dd-1335-aaaa-d4d10fecf113", email="test@fec.gov", username="gov")
 
     def test_disable_user_email(self):
         user_model = get_user_model()
@@ -29,16 +29,16 @@ class DisableUserCommandTest(TestCase):
     def test_disable_user_uuid(self):
         user_model = get_user_model()
 
-        # get the test user by username
-        user = user_model.objects.get(username=self.test_user.username)
+        # get the test user
+        user = user_model.objects.get(id=self.test_user.id)
         self.assertTrue(user.is_active)
 
-        # disable the test user by id
+        # disable the test user
         try:
             call_command("disable_user", uuid=user.id)
         except Exception as e:
             print(f"Error running command: {e}")
 
         # re-get the test user
-        user = user_model.objects.get(username=self.test_user.username)
+        user = user_model.objects.get(id=self.test_user.id)
         self.assertFalse(user.is_active)


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-2070

Related PRs:

Previously, the disable_user command required that an email be passed in. Now you may pass in an email OR a UUID, though you must pass in one.