### PR TITLE
2067- Fix committee UUID in logs, pretty-print exceptions locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ ENV PYTHONUNBUFFERED=1
 RUN mkdir /opt/nxg_fec
 WORKDIR /opt/nxg_fec
 ADD requirements.txt /opt
-RUN pip3 install -r /opt/requirements.txt
+ADD requirements-test.txt /opt
+RUN pip3 install -r /opt/requirements.txt && pip3 install -r /opt/requirements-test.txt
 
 RUN mv /etc/localtime /etc/localtime.backup && ln -s /usr/share/zoneinfo/EST5EDT /etc/localtime
 

--- a/django-backend/fecfiler/committee_accounts/views.py
+++ b/django-backend/fecfiler/committee_accounts/views.py
@@ -103,7 +103,7 @@ class CommitteeOwnedViewMixin(viewsets.GenericViewSet):
         committee_uuid = self.get_committee_uuid()
         committee_id = self.get_committee_id()
         structlog.contextvars.bind_contextvars(
-            committee_id=committee_id, committee_uuid=committee_id
+            committee_id=committee_id, committee_uuid=committee_uuid
         )
         return super().get_queryset().filter(committee_account_id=committee_uuid)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,9 @@ known_first_party = ["fecfiler", "locust_data_generator"]
 
 [tool.deptry.per_rule_ignores]
 DEP001 = ["locust"]
-DEP002 = ["gunicorn", "django-deprecate-fields", "django-migration-linter"]
+DEP002 = [
+    "gunicorn",
+    "django-deprecate-fields",
+    "django-migration-linter",
+    "rich"
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,5 @@ DEP001 = ["locust"]
 DEP002 = [
     "gunicorn",
     "django-deprecate-fields",
-    "django-migration-linter",
-    "rich"
+    "django-migration-linter"
 ]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,4 +2,5 @@ coverage==6.3
 deptry==0.21.1
 flake8==4.0.1
 liccheck==0.6.2
+rich==13.9.4
 sphinx==7.2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,6 @@ psycopg2-binary==2.9.10
 PyJWT==2.10.1
 redis==4.5.5
 requests==2.32.3
+rich==13.9.4
 structlog==24.4.0
 zeep==4.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,5 @@ psycopg2-binary==2.9.10
 PyJWT==2.10.1
 redis==4.5.5
 requests==2.32.3
-rich==13.9.4
 structlog==24.4.0
 zeep==4.2.1


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-2067
  
- Fix committee UUID in logs:
>2025-03-24 15:41:57 [info     ] request_finished               code=200 committee_id=C99999999 **committee_uuid=c94c5d1a-9e73-464d-ad72-b73b5d8667a9** ip=172.18.0.1 request=GET /api/v1/reports/?page=1&ordering=form_type&page_size=10 request_id=3dea8d93-7a85-4a8a-8121-2509e8ae5fd1 user_id=e100e1da-cbfc-4189-aece-d139048a8e0a
- Re-add pretty exceptions on local
<img width="472" alt="Screenshot 2025-03-24 at 3 47 53 PM" src="https://github.com/user-attachments/assets/bcf2c9d1-e0e0-43c8-ba31-94c7df0c0109" />

