### PR TITLE
Add cert files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ front-end/.vscode/launch.json
 
 # Celery Beat
 django-backend/celerybeat-schedule
+
+# login.gov certs
+*.crt


### PR DESCRIPTION
Ticket link: None
 
When we generate new certificate files for login.gov, we should make sure they aren't accidentally checked in to source control.
