### PR TITLE
feature/2106 - Fix to make migration hopeful work better with the migrator while also still passing linter

### DIFF
--- a/django-backend/fecfiler/reports/migrations/0012_alter_form99_text_code.py
+++ b/django-backend/fecfiler/reports/migrations/0012_alter_form99_text_code.py
@@ -1,20 +1,6 @@
 from django.db import migrations, models
 
 
-def copy_text_code_to_text_code_2(apps, schema_editor):
-    form_99 = apps.get_model("reports", "Form99")
-    for form in form_99.objects.all():
-        form.text_code_2 = form.text_code or ""
-        form.save(update_fields=["text_code_2"])
-
-
-def copy_text_code_2_to_text_code(apps, schema_editor):
-    form_99 = apps.get_model("reports", "Form99")
-    for form in form_99.objects.all():
-        form.text_code = form.text_code_2
-        form.save(update_fields=["text_code"])
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -26,20 +12,17 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="form99",
             name="text_code_2",
-            field=models.TextField(),
-        ),
-        migrations.RunPython(
-            copy_text_code_to_text_code_2,
-            reverse_code=copy_text_code_2_to_text_code,
+            field=models.TextField(db_default=""),
         ),
         migrations.RunSQL(
             sql="""
-                ALTER TABLE reports_form99 ALTER COLUMN text_code_2 SET NOT NULL;
+                UPDATE reports_form99 SET text_code_2 = COALESCE(text_code, '');
                 ALTER TABLE reports_form99 ALTER COLUMN text_code SET DEFAULT '';
+                ALTER TABLE reports_form99 ALTER COLUMN text_code_2 SET NOT NULL;
             """,
             reverse_sql="""
-                ALTER TABLE reports_form99 ALTER COLUMN text_code_2 DROP NOT NULL;
                 ALTER TABLE reports_form99 ALTER COLUMN text_code_2 DROP DEFAULT;
+                ALTER TABLE reports_form99 ALTER COLUMN text_code_2 DROP NOT NULL;
             """,
             state_operations=[
                 migrations.AlterField(


### PR DESCRIPTION
Issue [FECFILE-2106](https://fecgov.atlassian.net/browse/FECFILE-2106)


I feel much more comfortable with this. For testing locally I created a migration in between this one and the previous migration which created a Form 99 with a null text_code.
When I ran the old version of this migration, it crashed out the same way as what happened on dev. When I ran the new version presented in this PR, it passed.