### PR TITLE
Patch - Prevent reference before assignment error in dotFEC creation

### DIFF
--- a/django-backend/fecfiler/web_services/tasks.py
+++ b/django-backend/fecfiler/web_services/tasks.py
@@ -61,12 +61,17 @@ def create_dot_fec(
     force_write_to_disk=False,
     file_name=None,
 ):
+    submission = None
     if upload_submission_id:
         submission = UploadSubmission.objects.get(id=upload_submission_id)
         submission.save_state(FECSubmissionState.CREATING_FILE)
     if webprint_submission_id:
         submission = WebPrintSubmission.objects.get(id=webprint_submission_id)
         submission.save_state(FECSubmissionState.CREATING_FILE)
+
+    if submission is None:
+        raise ValueError("No UploadSubmission or WebPrintSubmission object found!")
+
     try:
         file_content = compose_dot_fec(report_id)
         if file_name is None:

--- a/django-backend/fecfiler/web_services/tasks.py
+++ b/django-backend/fecfiler/web_services/tasks.py
@@ -79,12 +79,11 @@ def create_dot_fec(
         store_file(file_content, file_name, force_write_to_disk)
         dot_fec_record = DotFEC(report_id=report_id, file_name=file_name)
         dot_fec_record.save()
-
-    except Exception:
-        logger.error("Creating .FEC failed")
+    except Exception as e:
+        logger.error(f"Creating .FEC for report {report_id} failed: {e}")
         if submission is not None:
             submission.save_error("Creating .FEC failed")
-        return None
+        raise e
 
     if upload_submission_id:
         UploadSubmission.objects.filter(id=upload_submission_id).update(

--- a/django-backend/fecfiler/web_services/tasks.py
+++ b/django-backend/fecfiler/web_services/tasks.py
@@ -69,9 +69,6 @@ def create_dot_fec(
         submission = WebPrintSubmission.objects.get(id=webprint_submission_id)
         submission.save_state(FECSubmissionState.CREATING_FILE)
 
-    if submission is None:
-        raise ValueError("No UploadSubmission or WebPrintSubmission object found!")
-
     try:
         file_content = compose_dot_fec(report_id)
         if file_name is None:
@@ -84,7 +81,9 @@ def create_dot_fec(
         dot_fec_record.save()
 
     except Exception:
-        submission.save_error("Creating .FEC failed")
+        logger.error("Creating .FEC failed")
+        if submission is not None:
+            submission.save_error("Creating .FEC failed")
         return None
 
     if upload_submission_id:


### PR DESCRIPTION
The create dotfec task raises a value error if there's neither a webprint submission nor an upload submission

Ticket link: https://fecgov.atlassian.net/browse/FECFILE-2153
  
Related PRs:
