### PR TITLE
2172 - Add email to account creation success/failure

### DIFF
--- a/django-backend/fecfiler/committee_accounts/test_utils.py
+++ b/django-backend/fecfiler/committee_accounts/test_utils.py
@@ -87,13 +87,13 @@ class CommitteeAccountsUtilsTest(TestCase):
 
     def test_no_f1_email(self):
         result = check_email_match("email3@example.com", None)
-        self.assertEqual(result, "No email provided in F1")
+        self.assertEqual(result, "no email provided in F1")
 
     def test_no_match(self):
         f1_emails = "email1@example.com;email2@example.com"
         result = check_email_match("email3@example.com", f1_emails)
         self.assertEqual(
-            result, "Email does not match committee email"
+            result, "email does not match committee email"
         )
 
     def test_match_semicolon(self):

--- a/django-backend/fecfiler/committee_accounts/utils.py
+++ b/django-backend/fecfiler/committee_accounts/utils.py
@@ -36,12 +36,12 @@ def check_email_match(email, f1_emails):
         returns a string indicating the mismatch. Otherwise, returns None.
     """
     if not f1_emails:
-        return "No email provided in F1"
+        return "no email provided in F1"
     else:
         f1_email_lowercase = f1_emails.lower()
         f1_emails = re.split(r"[;,]", f1_email_lowercase)
         if email.lower() not in f1_emails:
-            return "Email does not match committee email"
+            return "email does not match committee email"
     return None
 
 
@@ -53,11 +53,12 @@ def check_can_create_committee_account(committee_id, user):
 
     existing_account = CommitteeAccount.objects.filter(committee_id=committee_id).first()
     if existing_account:
-        failure_reason = f"Committee account {committee_id} already created"
+        failure_reason = "account already created"
 
     if failure_reason:
         logger.error(
-            f"User {user.id} failed to create committee account: {failure_reason}"
+            f"User {user.email} failed to create committee account "
+            f"{committee_id}: {failure_reason}"
         )
         return False
 
@@ -73,6 +74,10 @@ def create_committee_account(committee_id, user):
         committee_account=account,
         user=user,
         role=Membership.CommitteeRole.COMMITTEE_ADMINISTRATOR,
+    )
+
+    logger.info(
+        f"User {user.email} successfully created committee account {committee_id}"
     )
 
     return account


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-2172 and https://fecgov.atlassian.net/browse/FOSEC-47
  

**How to test locally**
- Hook up to stage openFEC with `FLAG__COMMITTEE_DATA_SOURCE: TEST` in docker-compose
- set `STAGE_OPEN_FEC_API_KEY` to something with a higher rate limit than `DEMO_KEY` - ask team in Slack or sign up for one here: https://api.open.fec.gov/developers/
- Change "email" to your email in `django-backend/fixtures/e2e-test-data.json`
- Change "test_email" to your email in `django-backend/fecfiler/mock_oidc_provider/views.py`
- Rebuild your docker containers
- Run the app locally 
- Try to create an account for a committee where your email matches: https://api-stage.open.fec.gov/v1/efile/test-form1/?api_key=DEMO_KEY&sort=-load_timestamp&per_page=100
- Try to create an account for a committee where your email doesn't match: https://api-stage.open.fec.gov/v1/efile/test-form1/?api_key=DEMO_KEY&sort=-load_timestamp&per_page=100


<code>
2025-04-25 13:13:20 [error    ] User lbeaufort@fec.gov failed to create committee account C00102509: email does not match committee email ip=172.18.0.1 request_id=81dd465f-479f-4374-b5d8-9038936f69ba user_id=e100e1da-cbfc-4189-aece-d139048a8e0a 
2025-04-25 13:32:53 [info     ] User lbeaufort@fec.gov successfully created committee account C00102327 ip=172.18.0.1 request_id=7bbb36ae-4561-4347-bd13-8e058f423c39 user_id=e100e1da-cbfc-4189-aece-d139048a8e0a
</code>
