### PR TITLE
FECFILE-2026: Send ERRORs to stderr not stdout

### DIFF
--- a/django-backend/fecfiler/committee_accounts/views.py
+++ b/django-backend/fecfiler/committee_accounts/views.py
@@ -252,7 +252,7 @@ class CommitteeMembershipViewSet(CommitteeOwnedViewMixin, viewsets.ModelViewSet)
                 )
             return Response({"success": "Membership removed."})
         except ValidationError as e:
-            logger.info(f"{str(e)}")
+            logger.error(f"{str(e)}")
             return Response({"error": str(e)}, status=400)
 
     def update(self, request, *args, **kwargs):

--- a/django-backend/fecfiler/devops/management/commands/fecfile_base.py
+++ b/django-backend/fecfiler/devops/management/commands/fecfile_base.py
@@ -48,7 +48,7 @@ class FECCommand(BaseCommand):
     def log(self, msg, level: Levels):
         match level:
             case Levels.ERROR:
-                self.stdout.write(self.style.ERROR(msg))
+                self.stderr.write(self.style.ERROR(msg))
             case Levels.SUCCESS:
                 if self.verbosity > 0:
                     self.stdout.write(self.style.SUCCESS(msg))
@@ -99,4 +99,4 @@ class FECCommand(BaseCommand):
                     self.stdout.write(self.style.MIGRATE_LABEL(msg))
             case Levels.ERROR_OUTPUT:
                 if self.verbosity > 0:
-                    self.stdout.write(self.style.ERROR_OUTPUT(msg))
+                    self.stderr.write(self.style.ERROR_OUTPUT(msg))

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -224,9 +224,11 @@ SPECTACULAR_SETTINGS = {
     "SERVE_INCLUDE_SCHEMA": False,
 }
 
+
 class NotErrorFilter(logging.Filter):
     def filter(self, record):
         return record.levelno < logging.ERROR
+
 
 def get_logging_config(log_format=LINE):
     logging_config = {


### PR DESCRIPTION
Ticket link:
https://fecgov.atlassian.net/browse/FECFILE-2026
  
Related PRs:
N/A

## Testing Locally.
To only view stderr: `docker logs [container-id] -f 1>/dev/null`
To only view stdout: `docker logs [container-id] -f 2>/dev/null`