### PR TITLE
FECFILE-1656: prior loans debts carry forward

### DIFF
--- a/django-backend/fecfiler/reports/models.py
+++ b/django-backend/fecfiler/reports/models.py
@@ -112,13 +112,12 @@ class Report(CommitteeOwnedModel):
                 carry_forward_loans(self)
                 carry_forward_debts(self)
 
-    def get_future_in_progress_reports(
+    def get_future_reports(
         self,
     ):
         return Report.objects.get_queryset().filter(
             ~Q(id=self.id),
             committee_account=self.committee_account_id,
-            upload_submission__isnull=True,
             coverage_through_date__gte=self.coverage_through_date,
         )
 

--- a/django-backend/fecfiler/transactions/schedule_c/views.py
+++ b/django-backend/fecfiler/transactions/schedule_c/views.py
@@ -19,7 +19,7 @@ def create_in_future_reports(transaction: Transaction):
     current_report = transaction.reports.filter(
         Q(form_3x__isnull=False) | Q(form_3__isnull=False)
     ).first()
-    future_reports = current_report.get_future_in_progress_reports()
+    future_reports = current_report.get_future_reports()
     transaction_copy = copy.deepcopy(transaction)
     for report in future_reports:
         carry_forward_loan(transaction_copy, report)
@@ -29,7 +29,7 @@ def update_in_future_reports(transaction: Transaction):
     current_report = transaction.reports.filter(
         Q(form_3x__isnull=False) | Q(form_3__isnull=False)
     ).first()
-    future_reports = current_report.get_future_in_progress_reports()
+    future_reports = current_report.get_future_reports()
     transaction_copy = copy.deepcopy(model_to_dict(transaction))
     # model_to_dict doesn't copy id
     del transaction_copy["reports"]

--- a/django-backend/fecfiler/transactions/schedule_c2/views.py
+++ b/django-backend/fecfiler/transactions/schedule_c2/views.py
@@ -18,7 +18,7 @@ def create_in_future_reports(transaction):
     current_report = transaction.reports.filter(
         Q(form_3x__isnull=False) | Q(form_3__isnull=False)
     ).first()
-    future_reports = current_report.get_future_in_progress_reports()
+    future_reports = current_report.get_future_reports()
     for report in future_reports:
         loan_query = Transaction.objects.filter(
             reports__id=report.id, loan_id=transaction.parent_transaction.id
@@ -33,7 +33,7 @@ def update_in_future_reports(transaction):
     current_report = transaction.reports.filter(
         Q(form_3x__isnull=False) | Q(form_3__isnull=False)
     ).first()
-    future_reports = current_report.get_future_in_progress_reports()
+    future_reports = current_report.get_future_reports()
 
     transaction_copy = copy.deepcopy(model_to_dict(transaction))
     # model_to_dict doesn't copy id

--- a/django-backend/fecfiler/transactions/schedule_d/views.py
+++ b/django-backend/fecfiler/transactions/schedule_d/views.py
@@ -20,7 +20,7 @@ def create_in_future_reports(transaction):
     current_report = transaction.reports.filter(
         Q(form_3x__isnull=False) | Q(form_3__isnull=False)
     ).first()
-    future_reports = current_report.get_future_in_progress_reports()
+    future_reports = current_report.get_future_reports()
     transaction_copy = copy.deepcopy(transaction)
     logger.info(
         f"Pulling debt forward from {current_report.id} "
@@ -34,7 +34,7 @@ def update_in_future_reports(transaction):
     future_reports = (
         transaction.reports.filter(Q(form_3x__isnull=False) | Q(form_3__isnull=False))
         .first()
-        .get_future_in_progress_reports()
+        .get_future_reports()
     )
 
     transaction_copy = copy.deepcopy(model_to_dict(transaction))

--- a/django-backend/fecfiler/transactions/tests/test_models.py
+++ b/django-backend/fecfiler/transactions/tests/test_models.py
@@ -79,6 +79,15 @@ class TransactionModelTestCase(TestCase):
             report=self.m1_report,
         )
 
+        # Submit the M2 report to test with a submitted report as well
+        self.m2_report.upload_submission = UploadSubmission.objects.initiate_submission(
+            self.m2_report.id
+        )
+        self.m2_report.refresh_from_db()
+        self.m2_report.upload_submission.fec_status = FECStatus.ACCEPTED
+        self.m2_report.upload_submission.save()
+        self.m2_report.refresh_from_db()
+
         carry_forward_loans(self.m2_report)
         self.carried_forward_loan = (
             Transaction.objects.transaction_view()

--- a/django-backend/fecfiler/transactions/views.py
+++ b/django-backend/fecfiler/transactions/views.py
@@ -775,7 +775,7 @@ def delete_carried_forward_loans_if_needed(transaction: Transaction, committee_i
             current_report = transaction.reports.filter(
                 Q(form_3x__isnull=False) | Q(form_3__isnull=False)
             ).first()
-            future_reports = current_report.get_future_in_progress_reports()
+            future_reports = current_report.get_future_reports()
             transactions_to_delete = list(
                 Transaction.objects.filter(
                     loan_id=original_loan_id,
@@ -795,7 +795,7 @@ def delete_carried_forward_debts_if_needed(transaction: Transaction, committee_i
             current_report = transaction.reports.filter(
                 Q(form_3x__isnull=False) | Q(form_3__isnull=False)
             ).first()
-            future_reports = current_report.get_future_in_progress_reports()
+            future_reports = current_report.get_future_reports()
             transactions_to_delete = list(
                 Transaction.objects.filter(
                     debt_id=original_debt_id,


### PR DESCRIPTION
Ticket link:
https://fecgov.atlassian.net/browse/FECFILE-1656

Related PRs:
N/A

### Notes for Peer Review:
* Testing instructions may be found in the ticket description.
* Please note that this PR the function `get_future_in_progress_reports()` is changed to `get_future_reports()`, removing the filter for non-submitted reports.  In consultation with @toddlees, it was believed that, in addition to the one call related to this ticket where we want to carry loans/debts forward for future reports regardless of whether they are in progress or already submitted, we would want the same in the remaining seven other places where this function were used.  Please give this a thorough interrogation.