### PR TITLE
FECFILE-2316: Updated requirements.txt with latest fecfile-validate hash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ django-structlog==9.1.1
 Django==5.2.2
 djangorestframework==3.16.0
 drf-spectacular==0.28.0
-git+https://github.com/fecgov/fecfile-validate@eec408ed09dc8728dfe1fc8703f0e8e454d55c53#egg=fecfile_validate&subdirectory=fecfile_validate_python
+git+https://github.com/fecgov/fecfile-validate@b7935d39de7be69b4cd1606c78bb0fda72c84e28#egg=fecfile_validate&subdirectory=fecfile_validate_python
 github3.py==4.0.1
 GitPython==3.1.43
 gunicorn==23.0.0


### PR DESCRIPTION
Ticket link:
 https://fecgov.atlassian.net/browse/FECFILE-2316

Related PRs:
https://github.com/fecgov/fecfile-validate/pull/367
https://github.com/fecgov/fecfile-web-app/pull/2886