### PR TITLE
FECFILE-2061: logging update

### DIFF
--- a/django-backend/fecfiler/web_services/dot_fec/dot_fec_submitter.py
+++ b/django-backend/fecfiler/web_services/dot_fec/dot_fec_submitter.py
@@ -60,7 +60,10 @@ class EFODotFECSubmitter(DotFECSubmitter):
 
     def submit(self, dot_fec_bytes, json_payload, fec_report_id=None):
         response = self.fec_soap_client.service.upload(json_payload, dot_fec_bytes)
-        logger.debug(f"FEC upload response: {response}")
+        if response.status != FECStatus.ACCEPTED.value:
+            logger.error(f"FEC upload failed: {response}")
+        else:
+            logger.info(f"FEC upload successful: {response}")
         return response
 
     def poll_status(self, submission: BaseSubmission):

--- a/django-backend/fecfiler/web_services/dot_fec/dot_fec_submitter.py
+++ b/django-backend/fecfiler/web_services/dot_fec/dot_fec_submitter.py
@@ -62,15 +62,21 @@ class EFODotFECSubmitter(DotFECSubmitter):
             self.mock = True
             self.mock_submitter = MockDotFECSubmitter()
         else:
-            self.fec_soap_client = Client(f"{EFO_FILING_API}/webload/services/upload?wsdl")
+            self.fec_soap_client = Client(
+                f"{EFO_FILING_API}/webload/services/upload?wsdl"
+            )
 
     def submit(self, dot_fec_bytes, json_payload, fec_report_id=None):
         if self.mock:
-            response = self.mock_submitter.submit(dot_fec_bytes, json_payload, fec_report_id)
-            response_obj = json.loads(response, object_hook=lambda d: SimpleNamespace(**d))
+            response = self.mock_submitter.submit(
+                dot_fec_bytes, json_payload, fec_report_id
+            )
         else:
-            response = self.fec_soap_client.service.upload(json_payload, dot_fec_bytes)
+            response = self.fec_soap_client.service.upload(
+                json_payload, dot_fec_bytes
+            )
 
+        response_obj = json.loads(response, object_hook=lambda d: SimpleNamespace(**d))
         if response_obj.status != FECStatus.ACCEPTED.value:
             logger.error(f"FEC upload failed: {response}")
         else:

--- a/django-backend/fecfiler/web_services/dot_fec/dot_fec_submitter.py
+++ b/django-backend/fecfiler/web_services/dot_fec/dot_fec_submitter.py
@@ -2,7 +2,6 @@ import copy
 import json
 from uuid import uuid4 as uuid
 from zeep import Client
-from abc import ABC, abstractmethod
 from types import SimpleNamespace
 from fecfiler.web_services.models import FECStatus, BaseSubmission
 from fecfiler.settings import (

--- a/django-backend/fecfiler/web_services/dot_fec/tests/test_dot_fec_submitter.py
+++ b/django-backend/fecfiler/web_services/dot_fec/tests/test_dot_fec_submitter.py
@@ -1,7 +1,7 @@
 import json
 from uuid import uuid4 as uuid
 from django.test import TestCase
-from fecfiler.web_services.dot_fec.dot_fec_submitter import MockDotFECSubmitter
+from fecfiler.web_services.dot_fec.dot_fec_submitter import EFODotFECSubmitter
 from fecfiler.web_services.dot_fec.web_print_submitter import MockWebPrintSubmitter
 from fecfiler.web_services.models import DotFEC, UploadSubmission, WebPrintSubmission
 from fecfiler.web_services.tasks import create_dot_fec
@@ -21,7 +21,8 @@ class DotFECSubmitterTestCase(TestCase):
         self.dot_fec_record = DotFEC.objects.get(id=self.dot_fec_id)
 
     def test_get_submission_json(self):
-        submitter = MockDotFECSubmitter()
+        submitter = EFODotFECSubmitter()
+        submitter.force_mock()  # Force mock for testing
         json_str = submitter.get_submission_json(
             self.dot_fec_record, "test_json_password"
         )
@@ -31,7 +32,8 @@ class DotFECSubmitterTestCase(TestCase):
         self.assertFalse(json_obj["wait"])
 
     def test_get_submission_json_for_amendment(self):
-        submitter = MockDotFECSubmitter()
+        submitter = EFODotFECSubmitter()
+        submitter.force_mock()  # Force mock for testing
         self.dot_fec_record.report.report_id = str(uuid())
         json_str = submitter.get_submission_json(
             self.dot_fec_record, "test_json_password", "test_backdoor_code"
@@ -43,7 +45,8 @@ class DotFECSubmitterTestCase(TestCase):
         )
 
     def test_poll(self):
-        submitter = MockDotFECSubmitter()
+        submitter = EFODotFECSubmitter()
+        submitter.force_mock()  # Force mock for testing
         response = submitter.poll_status(UploadSubmission())
         response_obj = json.loads(response)
         self.assertEqual(response_obj["status"], "ACCEPTED")

--- a/django-backend/fecfiler/web_services/dot_fec/web_print_submitter.py
+++ b/django-backend/fecfiler/web_services/dot_fec/web_print_submitter.py
@@ -35,7 +35,9 @@ class EFOWebPrintSubmitter(WebPrintSubmitter):
             self.mock = True
             self.mock_submitter = MockWebPrintSubmitter()
         else:
-            self.fec_soap_client = Client(f"{EFO_FILING_API}/webprint/services/print?wsdl")
+            self.fec_soap_client = Client(
+                f"{EFO_FILING_API}/webprint/services/print?wsdl"
+            )
 
     def submit(self, email, dot_fec_bytes):
         if self.mock:

--- a/django-backend/fecfiler/web_services/dot_fec/web_print_submitter.py
+++ b/django-backend/fecfiler/web_services/dot_fec/web_print_submitter.py
@@ -32,7 +32,10 @@ class EFOWebPrintSubmitter(WebPrintSubmitter):
         response = self.fec_soap_client.service.print(
             EFO_FILING_API_KEY, email, dot_fec_bytes
         )
-        logger.debug(f"FEC upload response: {response}")
+        if response.status != FECStatus.ACCEPTED.value:
+            logger.error(f"FEC upload failed: {response}")
+        else:
+            logger.info(f"FEC upload successful: {response}")
         return response
 
     def poll_status(self, submission: BaseSubmission):

--- a/django-backend/fecfiler/web_services/dot_fec/web_print_submitter.py
+++ b/django-backend/fecfiler/web_services/dot_fec/web_print_submitter.py
@@ -48,7 +48,7 @@ class EFOWebPrintSubmitter(WebPrintSubmitter):
             )
 
         response_obj = json.loads(response, object_hook=lambda d: SimpleNamespace(**d))
-        if response_obj.status != FECStatus.ACCEPTED.value:
+        if response_obj.status != FECStatus.COMPLETED.value:
             logger.error(f"FEC upload failed: {response}")
         else:
             logger.info(f"FEC upload successful: {response}")

--- a/django-backend/fecfiler/web_services/tasks.py
+++ b/django-backend/fecfiler/web_services/tasks.py
@@ -12,7 +12,6 @@ from fecfiler.web_services.models import (
 from fecfiler.web_services.dot_fec.dot_fec_composer import compose_dot_fec
 from fecfiler.web_services.dot_fec.dot_fec_submitter import (
     EFODotFECSubmitter,
-    MockDotFECSubmitter,
 )
 from fecfiler.web_services.dot_fec.web_print_submitter import (
     EFOWebPrintSubmitter,

--- a/django-backend/fecfiler/web_services/tasks.py
+++ b/django-backend/fecfiler/web_services/tasks.py
@@ -36,18 +36,15 @@ logger = structlog.get_logger(__name__)
 WEB_PRINT_KEY = "WebPrint"
 MOCK_WEB_PRINT_KEY = "MockWebPrint"
 EFO_SUBMITTER_KEY = "DotFEC"
-MOCK_SUBMITTER_KEY = "MockDotFEC"
 SUBMISSION_MANAGERS = {
     WEB_PRINT_KEY: EFOWebPrintSubmitter,
     MOCK_WEB_PRINT_KEY: MockWebPrintSubmitter,
     EFO_SUBMITTER_KEY: EFODotFECSubmitter,
-    MOCK_SUBMITTER_KEY: MockDotFECSubmitter,
 }
 SUBMISSION_CLASSES = {
     WEB_PRINT_KEY: WebPrintSubmission,
     MOCK_WEB_PRINT_KEY: WebPrintSubmission,
     EFO_SUBMITTER_KEY: UploadSubmission,
-    MOCK_SUBMITTER_KEY: UploadSubmission,
 }
 
 MAX_ATTEMPTS = INITIAL_POLLING_MAX_ATTEMPTS + SECONDARY_POLLING_MAX_ATTEMPTS
@@ -154,7 +151,7 @@ def submit_to_fec(
 
     """Submit to FEC"""
     try:
-        submission_type_key = EFO_SUBMITTER_KEY  # if not mock else MOCK_SUBMITTER_KEY
+        submission_type_key = EFO_SUBMITTER_KEY
         submitter = SUBMISSION_MANAGERS[submission_type_key]()
         logger.info(f"Uploading {file_name} to FEC")
         submission_json = submitter.get_submission_json(

--- a/django-backend/fecfiler/web_services/tasks.py
+++ b/django-backend/fecfiler/web_services/tasks.py
@@ -154,7 +154,7 @@ def submit_to_fec(
 
     """Submit to FEC"""
     try:
-        submission_type_key = EFO_SUBMITTER_KEY if not mock else MOCK_SUBMITTER_KEY
+        submission_type_key = EFO_SUBMITTER_KEY #if not mock else MOCK_SUBMITTER_KEY
         submitter = SUBMISSION_MANAGERS[submission_type_key]()
         logger.info(f"Uploading {file_name} to FEC")
         submission_json = submitter.get_submission_json(

--- a/django-backend/fecfiler/web_services/tasks.py
+++ b/django-backend/fecfiler/web_services/tasks.py
@@ -35,19 +35,19 @@ logger = structlog.get_logger(__name__)
 
 WEB_PRINT_KEY = "WebPrint"
 MOCK_WEB_PRINT_KEY = "MockWebPrint"
-DOT_FEC_KEY = "DotFEC"
-MOCK_DOT_FEC_KEY = "MockDotFEC"
+EFO_SUBMITTER_KEY = "DotFEC"
+MOCK_SUBMITTER_KEY = "MockDotFEC"
 SUBMISSION_MANAGERS = {
     WEB_PRINT_KEY: EFOWebPrintSubmitter,
     MOCK_WEB_PRINT_KEY: MockWebPrintSubmitter,
-    DOT_FEC_KEY: EFODotFECSubmitter,
-    MOCK_DOT_FEC_KEY: MockDotFECSubmitter,
+    EFO_SUBMITTER_KEY: EFODotFECSubmitter,
+    MOCK_SUBMITTER_KEY: MockDotFECSubmitter,
 }
 SUBMISSION_CLASSES = {
     WEB_PRINT_KEY: WebPrintSubmission,
     MOCK_WEB_PRINT_KEY: WebPrintSubmission,
-    DOT_FEC_KEY: UploadSubmission,
-    MOCK_DOT_FEC_KEY: UploadSubmission,
+    EFO_SUBMITTER_KEY: UploadSubmission,
+    MOCK_SUBMITTER_KEY: UploadSubmission,
 }
 
 MAX_ATTEMPTS = INITIAL_POLLING_MAX_ATTEMPTS + SECONDARY_POLLING_MAX_ATTEMPTS
@@ -154,7 +154,7 @@ def submit_to_fec(
 
     """Submit to FEC"""
     try:
-        submission_type_key = DOT_FEC_KEY if not mock else MOCK_DOT_FEC_KEY
+        submission_type_key = EFO_SUBMITTER_KEY if not mock else MOCK_SUBMITTER_KEY
         submitter = SUBMISSION_MANAGERS[submission_type_key]()
         logger.info(f"Uploading {file_name} to FEC")
         submission_json = submitter.get_submission_json(

--- a/django-backend/fecfiler/web_services/tasks.py
+++ b/django-backend/fecfiler/web_services/tasks.py
@@ -154,7 +154,7 @@ def submit_to_fec(
 
     """Submit to FEC"""
     try:
-        submission_type_key = EFO_SUBMITTER_KEY #if not mock else MOCK_SUBMITTER_KEY
+        submission_type_key = EFO_SUBMITTER_KEY  # if not mock else MOCK_SUBMITTER_KEY
         submitter = SUBMISSION_MANAGERS[submission_type_key]()
         logger.info(f"Uploading {file_name} to FEC")
         submission_json = submitter.get_submission_json(

--- a/django-backend/fecfiler/web_services/tests/test_tasks.py
+++ b/django-backend/fecfiler/web_services/tests/test_tasks.py
@@ -31,7 +31,6 @@ from fecfiler.web_services.dot_fec.web_print_submitter import (
     MockWebPrintSubmitter,
 )
 from fecfiler.web_services.dot_fec.dot_fec_submitter import EFODotFECSubmitter
-from uuid import uuid4 as uuid
 from fecfiler.settings import (
     INITIAL_POLLING_MAX_ATTEMPTS,
     SECONDARY_POLLING_MAX_ATTEMPTS,

--- a/django-backend/fecfiler/web_services/tests/test_tasks.py
+++ b/django-backend/fecfiler/web_services/tests/test_tasks.py
@@ -122,7 +122,7 @@ class TasksTestCase(TestCase):
             upload_submission_id=upload_submission.id,
             force_write_to_disk=True,
         )
-        upload_id = submit_to_fec(
+        submit_to_fec(
             dot_fec_id,
             upload_submission.id,
             "test_password",
@@ -131,14 +131,13 @@ class TasksTestCase(TestCase):
             True,
         )
         upload_submission.refresh_from_db()
-        self.assertEqual(upload_id, upload_submission.id)
         self.assertEqual(upload_submission.dot_fec_id, dot_fec_id)
         self.assertEqual(
             upload_submission.fecfile_task_state, FECSubmissionState.SUCCEEDED.value
         )
         self.assertIsNone(upload_submission.fecfile_error)
         self.assertEqual(upload_submission.fec_submission_id, "fake_submission_id")
-        self.assertEqual(upload_submission.fec_status, FECStatus.ACCEPTED.value)
+        self.assertEqual(upload_submission.fec_status, FECStatus.PROCESSING.value)
         self.assertEqual(
             upload_submission.fec_message, "We didn't really send anything to FEC"
         )

--- a/django-backend/fecfiler/web_services/tests/test_tasks.py
+++ b/django-backend/fecfiler/web_services/tests/test_tasks.py
@@ -285,14 +285,14 @@ class PollingTasksTestCase(TestCase):
             self.test_print_key: WebPrintSubmission,
         }
 
-        self.mock_dot_fec_key = "MockDotFEC"
+        self.mock_submitter_key = "MockDotFEC"
         self.test_dot_fec_key = "UnitTestDotFec"
         self.test_dot_fec_submission_managers = {
-            self.mock_dot_fec_key: MockDotFECSubmitter,
+            self.mock_submitter_key: MockDotFECSubmitter,
             self.test_dot_fec_key: UnitTestDotFecSubmitter,
         }
         self.test_dot_fec_submission_classes = {
-            self.mock_dot_fec_key: UploadSubmission,
+            self.mock_submitter_key: UploadSubmission,
             self.test_dot_fec_key: UploadSubmission,
         }
 
@@ -308,7 +308,7 @@ class PollingTasksTestCase(TestCase):
             self.assertNotEqual(upload_submission.fec_status, FECStatus.COMPLETED)
             poll_for_fec_response(
                 upload_submission.id,
-                self.mock_dot_fec_key,
+                self.mock_submitter_key,
                 "Unit Testing Upload Submission",
             )
             resolved_submission = UploadSubmission.objects.get(id=upload_submission.id)

--- a/django-backend/fecfiler/web_services/tests/test_tasks.py
+++ b/django-backend/fecfiler/web_services/tests/test_tasks.py
@@ -30,7 +30,7 @@ from fecfiler.web_services.dot_fec.web_print_submitter import (
     WebPrintSubmitter,
     MockWebPrintSubmitter,
 )
-from fecfiler.web_services.dot_fec.dot_fec_submitter import MockDotFECSubmitter
+from fecfiler.web_services.dot_fec.dot_fec_submitter import EFODotFECSubmitter
 from uuid import uuid4 as uuid
 from fecfiler.settings import (
     INITIAL_POLLING_MAX_ATTEMPTS,
@@ -239,19 +239,6 @@ class UnitTestWebPrintSubmitter(WebPrintSubmitter):
         )
 
 
-class UnitTestDotFecSubmitter(MockDotFECSubmitter):
-    # A stand-in DotFECSubmitter that returns PROCESSING on submission
-    def submit(self, dot_fec_bytes, json_payload, fec_report_id=None):
-        return json.dumps(
-            {
-                "submission_id": "fake_submission_id",
-                "status": FECStatus.PROCESSING.value,
-                "message": "We didn't really send anything to FEC",
-                "report_id": fec_report_id or str(uuid()),
-            }
-        )
-
-
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True, CELERY_TASK_EAGER_PROPOGATES=True)
 class PollingTasksTestCase(TestCase):
 
@@ -286,14 +273,11 @@ class PollingTasksTestCase(TestCase):
         }
 
         self.mock_submitter_key = "MockDotFEC"
-        self.test_dot_fec_key = "UnitTestDotFec"
         self.test_dot_fec_submission_managers = {
-            self.mock_submitter_key: MockDotFECSubmitter,
-            self.test_dot_fec_key: UnitTestDotFecSubmitter,
+            self.mock_submitter_key: EFODotFECSubmitter,
         }
         self.test_dot_fec_submission_classes = {
             self.mock_submitter_key: UploadSubmission,
-            self.test_dot_fec_key: UploadSubmission,
         }
 
     def test_dotfec_submission_polling_completes(self):

--- a/django-backend/fecfiler/web_services/tests/test_tasks.py
+++ b/django-backend/fecfiler/web_services/tests/test_tasks.py
@@ -115,7 +115,8 @@ class TasksTestCase(TestCase):
     SUBMIT TO FEC TESTS
     """
 
-    def test_submit_to_fec(self):
+    @patch("fecfiler.web_services.tasks.poll_for_fec_response")
+    def test_submit_to_fec(self, mock_poll_for_fec_response):
         upload_submission = UploadSubmission.objects.initiate_submission(str(self.f3x.id))
         dot_fec_id = create_dot_fec(
             str(self.f3x.id),
@@ -133,7 +134,7 @@ class TasksTestCase(TestCase):
         upload_submission.refresh_from_db()
         self.assertEqual(upload_submission.dot_fec_id, dot_fec_id)
         self.assertEqual(
-            upload_submission.fecfile_task_state, FECSubmissionState.SUCCEEDED.value
+            upload_submission.fecfile_task_state, FECSubmissionState.SUBMITTING.value
         )
         self.assertIsNone(upload_submission.fecfile_error)
         self.assertEqual(upload_submission.fec_submission_id, "fake_submission_id")


### PR DESCRIPTION
Ticket link:
https://fecgov.atlassian.net/browse/FECFILE-2061

Related PRs:
None (as yet)

There are a few things going on here:
1.) After discussion, DOT_FEC_KEY was renamed to EFO_SUBMITTER_KEY and MOCK_DOT_FEC_KEY was renamed to MOCK_SUBMITTER_KEY.
2.) The logging was updated as requested in the ticket.
3.) Removed the DotFECSubmitter ABC.

That last one may get me in trouble and I'm completely open to the possibility that I've taken a wrong turn. My thinking is that many mock versions simply return some JSON -- and often the same JSON regardless of the method, so why not instead have a class that returns different JSON payloads on one hand and on the other hand always use the "real" submitter but have it differentiate between whether the response object should get a mock response or a real one?

There are a few bits that I would like to refactor further but that could be a follow-up ticket.