### PR TITLE
feature/2371 - Set initial polling to happen instantly rather than after a delay, so if Submission finishes instantly (like in testing) it doesn't need to wait 30 seconds

### DIFF
--- a/django-backend/fecfiler/web_services/tasks.py
+++ b/django-backend/fecfiler/web_services/tasks.py
@@ -174,10 +174,8 @@ def submit_to_fec(
             the submission id and a key that we can use to determine the type of the
             submission.  This lets us instantiate objects of the correct classes as we
             need them."""
-            countdown = calculate_polling_interval(submission.fecfile_polling_attempts)
             return poll_for_fec_response.apply_async(
-                [submission.id, submission_type_key, "Dot FEC"],
-                countdown=countdown,
+                [submission.id, submission_type_key, "Dot FEC"]
             )
         else:
             return resolve_final_submission_state(submission)


### PR DESCRIPTION
Issue [FECFILE-2371](https://fecgov.atlassian.net/browse/FECFILE-2371)

APP: [PR2925](https://github.com/fecgov/fecfile-web-app/pull/2925)