### PR TITLE
Feature/2433 - Celery log committee and user info

### DIFF
--- a/django-backend/fecfiler/celery.py
+++ b/django-backend/fecfiler/celery.py
@@ -34,7 +34,7 @@ def receiver_setup_logging(loglevel, logfile, format, colorize, **kwargs):
     Celery and environment-specific logging
     See https://django-structlog.readthedocs.io/en/latest/celery.html
     """
-    log_format = env.get_credential("LOG_FORMAT")
+    log_format = settings.LOG_FORMAT
 
     logging.config.dictConfig(settings.get_logging_config(log_format))
 

--- a/django-backend/fecfiler/celery.py
+++ b/django-backend/fecfiler/celery.py
@@ -4,10 +4,10 @@ import ssl
 import cfenv
 import logging
 import structlog
-from django.conf import settings
 from celery import Celery
 from celery.signals import setup_logging
 from django_structlog.celery.steps import DjangoStructLogInitStep
+from fecfiler import settings
 
 logger = structlog.get_logger(__name__)
 

--- a/django-backend/fecfiler/celery.py
+++ b/django-backend/fecfiler/celery.py
@@ -1,4 +1,3 @@
-from enum import Enum
 import os
 import ssl
 import cfenv
@@ -51,8 +50,3 @@ if env.get_service(name="fecfile-api-redis"):
 
 # Load task modules from all registered Django apps.
 app.autodiscover_tasks()
-
-
-class CeleryStorageType(Enum):
-    AWS = "aws"
-    LOCAL = "local"

--- a/django-backend/fecfiler/committee_accounts/views.py
+++ b/django-backend/fecfiler/committee_accounts/views.py
@@ -111,10 +111,6 @@ class CommitteeOwnedViewMixin(viewsets.GenericViewSet):
 
     def get_queryset(self):
         committee_uuid = self.get_committee_uuid()
-        committee_id = self.get_committee_id()
-        structlog.contextvars.bind_contextvars(
-            committee_id=committee_id, committee_uuid=committee_uuid
-        )
         return super().get_queryset().filter(committee_account_id=committee_uuid)
 
     def get_committee_uuid(self):
@@ -122,12 +118,6 @@ class CommitteeOwnedViewMixin(viewsets.GenericViewSet):
         if not committee_uuid:
             raise SuspiciousSession("session has invalid committee_uuid")
         return committee_uuid
-
-    def get_committee_id(self):
-        committee_id = self.request.session["committee_id"]
-        if not committee_id:
-            raise SuspiciousSession("session has invalid committee_id")
-        return committee_id
 
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())

--- a/django-backend/fecfiler/middleware.py
+++ b/django-backend/fecfiler/middleware.py
@@ -1,8 +1,25 @@
+import structlog
+
+
 class HeaderMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
 
     def __call__(self, request):
         response = self.get_response(request)
-        response['cache-control'] = "no-cache, no-store"
+        response["cache-control"] = "no-cache, no-store"
+        return response
+
+
+class StructlogContextMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        committee_uuid = request.session.get("committee_uuid")
+        committee_id = request.session.get("committee_id")
+        structlog.contextvars.bind_contextvars(
+            committee_id=committee_id, committee_uuid=committee_uuid
+        )
+        response = self.get_response(request)
         return response

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -8,12 +8,17 @@ import structlog
 import logging
 import sys
 
+from enum import Enum
 from .env import env
 from corsheaders.defaults import default_headers
-from fecfiler.celery import CeleryStorageType
 from fecfiler.shared.utilities import get_float_from_string, get_boolean_from_string
 from fecfiler.transactions.profilers import TRANSACTION_MANAGER_PROFILING
 from math import floor
+
+
+class CeleryStorageType(Enum):
+    AWS = "aws"
+    LOCAL = "local"
 
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -118,6 +123,7 @@ MIDDLEWARE += [
     "fecfiler.middleware.HeaderMiddleware",
     "fecfiler.oidc.middleware.TimeoutMiddleware.TimeoutMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "fecfiler.middleware.StructlogContextMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",

--- a/django-backend/fecfiler/web_services/web_service_storage.py
+++ b/django-backend/fecfiler/web_services/web_service_storage.py
@@ -5,7 +5,7 @@ from fecfiler.settings import (
     CELERY_LOCAL_STORAGE_DIRECTORY,
 )
 from fecfiler.s3 import S3_SESSION
-from fecfiler.celery import CeleryStorageType
+from fecfiler.settings import CeleryStorageType
 import structlog
 
 logger = structlog.get_logger(__name__)


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-2433
  
Related PRs:

This is how the logging looks:
<img width="1840" height="79" alt="image" src="https://github.com/user-attachments/assets/382a7d96-0c15-4704-8785-984e9e28deaf" />

This also improved the API logging where now the user/committee info is logged for every log statement originating from an http request (before some log statements didn't have it).