### PR TITLE
fix docker compose apps not starting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
       OUTPUT_TEST_INFO_IN_DOT_FEC:
       LOG_FORMAT:
       ENABLE_PL_SQL_LOGGING: False # Django DEBUG base.py setting must also be set to True to see SQL output
+      OIDC_OP_AUTODISCOVER_ENDPOINT: http://localhost:8080/api/v1/mock_oidc_provider/.well-known/openid-configuration
       FLAG__COMMITTEE_DATA_SOURCE: MOCKED # Values are PRODUCTION, TEST, and MOCKED
       ENABLE_RESTRICTED_COMMANDS: True
       FEC_FORMAT_VERSION: 8.4
@@ -103,6 +104,7 @@ services:
       OUTPUT_TEST_INFO_IN_DOT_FEC:
       LOG_FORMAT:
       ENABLE_PL_SQL_LOGGING: False # Django DEBUG base.py setting must also be set to True to see SQL output
+      OIDC_OP_AUTODISCOVER_ENDPOINT: http://localhost:8080/api/v1/mock_oidc_provider/.well-known/openid-configuration
       FLAG__COMMITTEE_DATA_SOURCE: MOCKED # Values are PRODUCTION, TEST, and MOCKED
       ENABLE_RESTRICTED_COMMANDS: True
       FEC_FORMAT_VERSION: 8.4


### PR DESCRIPTION
Ticket link: n/a
  
Related PRs: n/a

some docker compose apps were not starting due to missing required settings.py variable (scheduler, celery worker).  This env var is now required for startup. 
