### PR TITLE
FECFILE-2461: Update django from 5.2.2 to 5.2.6.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ django-cors-headers==4.7.0
 django-deprecate-fields==0.2.1
 django-migration-linter==5.2.0
 django-structlog==9.1.1
-Django==5.2.2
+Django==5.2.6
 djangorestframework==3.16.0
 drf-spectacular==0.28.0
 Faker==37.6.0


### PR DESCRIPTION
Ticket link:
https://fecgov.atlassian.net/browse/FECFILE-2461

Related PRs:
N/A