### PR TITLE
FECFILE-2681: Updated fecfile-validate hash.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Django==5.2.8
 djangorestframework==3.16.0
 drf-spectacular==0.28.0
 Faker==37.6.0
-git+https://github.com/fecgov/fecfile-validate@9808ad14eca981521633e8a4bdd03782054ff296#egg=fecfile_validate&subdirectory=fecfile_validate_python
+git+https://github.com/fecgov/fecfile-validate@52b80f642169eaf391356de224a875c5208b2a75#egg=fecfile_validate&subdirectory=fecfile_validate_python
 github3.py==4.0.1
 GitPython==3.1.43
 gunicorn==23.0.0


### PR DESCRIPTION
Ticket link:
https://fecgov.atlassian.net/browse/FECFILE-2681
  
Related PRs:
https://github.com/fecgov/fecfile-validate/pull/404
https://github.com/fecgov/fecfile-web-app/pull/3345