### PR TITLE
2645 - Don't profile silk static assets

### DIFF
--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -116,17 +116,16 @@ if INCLUDE_SILK:
         "django.contrib.staticfiles",
     ]
     MIDDLEWARE = ["silk.middleware.SilkyMiddleware"]
-    # Static files (CSS, JavaScript, Images)
-    # https://docs.djangoproject.com/en/1.11/howto/static-files/
 
     SILKY_PYTHON_PROFILER = True
-    # SILKY_PYTHON_PROFILER_BINARY = True
-    # https://github.com/jazzband/django-silk?tab=readme-ov-file#profiling
 
+    # Set SILKY_PYTHON_PROFILER_BINARY to True for cProfiling
+    SILKY_PYTHON_PROFILER_BINARY = False
+
+    # Don't profile static assets
     def custom_silk_filter(request):
         return STATIC_URL not in request.path
     SILKY_INTERCEPT_FUNC = custom_silk_filter
-    # Don't profile static assets
 
     SILKY_DYNAMIC_PROFILING = WEB_SERVICES_PROFILING
 


### PR DESCRIPTION
Ticket link: Related to https://fecgov.atlassian.net/browse/FECFILE-2645

https://github.com/fecgov/fecfile-web-api/tree/develop/performance-testing#silk-profiling
  
- Add custom `custom_silk_filter` to `SILKY_INTERCEPT_FUNC` to filter out static/silk assets
- Remove unused `STATICFILES_LOCATION` constant
- Set `SILKY_PYTHON_PROFILER_BINARY` to False - it was causing some binary clutter - we can always turn it back on https://github.com/jazzband/django-silk?tab=readme-ov-file#profiling

**Before**
<img width="1230" height="563" alt="Screenshot 2026-01-26 at 9 56 19 AM" src="https://github.com/user-attachments/assets/3282c3e9-a327-4b11-8191-7d47123a0359" />



**After**
<img width="1230" height="563" alt="Screenshot 2026-01-26 at 9 57 10 AM" src="https://github.com/user-attachments/assets/a2c39d44-ce4e-4c6b-b219-53f1adf27064" />
