### PR TITLE
Feature/2816 - Transaction List Query improvements

### DIFF
--- a/django-backend/fecfiler/reports/report_code_label.py
+++ b/django-backend/fecfiler/reports/report_code_label.py
@@ -59,6 +59,11 @@ report_code_label_case = Case(
     output_field=CharField(),
 )
 
+limited_label_case = Case(
+    *[When(report_code=k, then=Value(v)) for k, v in report_code_label_mapping.items()],
+    output_field=CharField(),
+)
+
 
 def get_report_code_label(report: Report):
     if report.form_3x or report.form_3:

--- a/django-backend/fecfiler/transactions/managers.py
+++ b/django-backend/fecfiler/transactions/managers.py
@@ -11,6 +11,10 @@ from fecfiler.transactions.schedule_e.managers import line_labels as line_labels
 from fecfiler.transactions.schedule_f.managers import line_labels as line_labels_f
 from django.db.models.functions import Coalesce, Concat
 from django.db.models import (
+    Q,
+    CharField,
+    DecimalField,
+    DateField,
     UUIDField,
     OuterRef,
     Subquery,
@@ -23,7 +27,11 @@ from django.db.models import (
 from decimal import Decimal
 from enum import Enum
 from ..reports.models import Report
-from fecfiler.reports.report_code_label import report_code_label_case, report_type_case
+from fecfiler.reports.report_code_label import (
+    report_code_label_case,
+    report_type_case,
+    limited_label_case,
+)
 
 
 """Manager to deterimine fields that are used the same way across transactions,
@@ -95,6 +103,193 @@ class TransactionManager(SoftDeleteManager):
             )
         )
 
+    def get_list_queryset(self, schedules_to_include, report_type, report_code_label):
+        active_schedules = (
+            schedules_to_include
+            if (schedules_to_include and len(schedules_to_include) > 0)
+            else self.DATE_MAPPING.keys()
+        )
+
+        schedule_clause = self.schedule_filter(active_schedules)
+        loan_expr, balance_expr = self.loan_balance_builder(active_schedules)
+        date_clause, amount_clause = self.date_amount_builder(active_schedules)
+        report_code_label_clause = self.report_code_label_builder(report_code_label)
+        report_type_clause = self.report_type_builder(report_type)
+        back_ref_id_clause = self.back_reference_builder(active_schedules)
+
+        return (
+            super()
+            .get_queryset()
+            .annotate(
+                schedule=schedule_clause,
+                date=date_clause,
+                amount=amount_clause,
+                loan_balance=loan_expr,
+                balance=balance_expr,
+                form_type=self.FORM_TYPE_CLAUSE,
+                name=self.DISPLAY_NAME_CLAUSE,
+                transaction_ptr_id=F("id"),
+                line_label=self.LINE_LABEL_CLAUSE(),
+                report_code_label=report_code_label_clause,
+                loan_agreement_id=self.LOAN_AGREEMENT_CLAUSE(),
+                report_type=report_type_clause,
+                back_reference_tran_id_number=back_ref_id_clause,
+            )
+            .alias(order_key=self.ORDER_KEY_CLAUSE())
+            .order_by("order_key")
+        )
+
+    def report_code_label_builder(self, report_code_label):
+        if report_code_label is None or report_code_label == "":
+            return Subquery(  # noqa: N806
+                Report.objects.filter(transactions=OuterRef("pk"), form_24__isnull=True)
+                .annotate(report_code_label=limited_label_case)
+                .values("report_code_label")[:1]
+            )
+        return Value(report_code_label, output_field=CharField())
+
+    def report_type_builder(self, report_type):
+        if report_type is None:
+            return self.REPORT_TYPE_CLAUSE()
+        CODE_TO_LABEL = {
+            "F3X": "Form 3X",
+            "F3": "Form 3",
+            "F24": "Form 24",
+            "F99": "Form 99",
+            "F1M": "Form 1M",
+        }
+        label = CODE_TO_LABEL.get(report_type, report_type)
+        return Value(label, output_field=CharField())
+
+    def loan_balance_builder(self, active_schedules):
+        is_c_active = "C" in active_schedules
+        is_d_active = "D" in active_schedules
+        if is_c_active:
+            loan_expr = F("amount") - Coalesce(
+                F("loan_payment_to_date"), Value(Decimal("0.0"))
+            )
+        else:
+            loan_expr = Value(None, output_field=DecimalField())
+
+        balance_cases = []
+
+        if is_d_active:
+            balance_cases.append(
+                When(
+                    schedule_d_id__isnull=False,
+                    then=Coalesce(
+                        F("schedule_d__balance_at_close"), Value(Decimal("0.0"))
+                    ),
+                )
+            )
+
+        if is_c_active:
+            balance_cases.append(
+                When(
+                    schedule_c_id__isnull=False,
+                    then=Coalesce(F("loan_balance"), Value(Decimal("0.0"))),
+                )
+            )
+
+        if balance_cases:
+            balance_expr = Case(*balance_cases, output_field=DecimalField())
+        else:
+            balance_expr = Value(None, output_field=DecimalField())
+
+        return loan_expr, balance_expr
+
+    def date_amount_builder(self, active_schedules):
+        date_args = []
+        amount_args = []
+        for sched in active_schedules:
+            date_fields = self.DATE_MAPPING.get(sched, [])
+            amount_fields = self.AMOUNT_MAPPING.get(sched, [])
+
+            for field in date_fields:
+                date_args.append(F(field))
+
+            for field in amount_fields:
+                amount_args.append(F(field))
+
+        if any(s in active_schedules for s in ["B", "D", "F"]):
+            amount_args.append(F("debt__schedule_d__incurred_amount"))
+
+        while len(date_args) < 2:
+            date_args.append(Value(None, output_field=DateField()))
+
+        while len(amount_args) < 2:
+            amount_args.append(Value(None, output_field=DecimalField()))
+
+        dynamic_date_clause = Coalesce(*date_args, output_field=DateField())
+        dynamic_amount_clause = Coalesce(*amount_args, output_field=DecimalField())
+        return dynamic_date_clause, dynamic_amount_clause
+
+    def schedule_filter(self, active_schedules):
+        schedule_cases = []
+        SCHEDULE_ENUM_MAP = {
+            "A": Schedule.A.value,
+            "B": Schedule.B.value,
+            "C": Schedule.C.value,
+            "C1": Schedule.C1.value,
+            "C2": Schedule.C2.value,
+            "D": Schedule.D.value,
+            "E": Schedule.E.value,
+            "F": Schedule.F.value,
+        }
+        SCHEDULE_FIELD_MAP = {
+            "A": "schedule_a__isnull",
+            "B": "schedule_b__isnull",
+            "C": "schedule_c__isnull",
+            "C1": "schedule_c1__isnull",
+            "C2": "schedule_c2__isnull",
+            "D": "schedule_d__isnull",
+            "E": "schedule_e__isnull",
+            "F": "schedule_f__isnull",
+        }
+
+        for sched_id in active_schedules:
+            field_check = SCHEDULE_FIELD_MAP.get(sched_id)
+            enum_value = SCHEDULE_ENUM_MAP.get(sched_id)
+
+            if field_check and enum_value:
+                schedule_cases.append(When(Q(**{field_check: False}), then=enum_value))
+
+        if schedule_cases:
+            return Case(*schedule_cases, output_field=TextField())
+        else:
+            return Value(None, output_field=TextField())
+
+    def back_reference_builder(self, active_schedules):
+        """
+        Builds a Coalesce expression that only includes joins for
+        relationships relevant to the active schedules.
+
+        Rules:
+        A:      parent, loan, reatt_redes
+        B:      parent, loan, debt, reatt_redes
+        C:      loan
+        D:      debt
+        C1/C2:  parent
+        E/F:    (none)
+        """
+        id_args = []
+
+        if any(s in active_schedules for s in ["A", "B"]):
+            id_args.append(F("reatt_redes__transaction_id"))
+
+        if any(s in active_schedules for s in ["A", "B", "C1", "C2"]):
+            id_args.append(F("parent_transaction__transaction_id"))
+
+        if any(s in active_schedules for s in ["B", "D"]):
+            id_args.append(F("debt__transaction_id"))
+
+        if any(s in active_schedules for s in ["A", "B", "C"]):
+            id_args.append(F("loan__transaction_id"))
+
+        id_args.append(Value(None))
+
+        return Coalesce(*id_args, output_field=TextField())
+
     DATE_CLAUSE = Coalesce(
         "schedule_a__contribution_date",
         "schedule_b__expenditure_date",
@@ -114,18 +309,6 @@ class TransactionManager(SoftDeleteManager):
         "debt__schedule_d__incurred_amount",
         "schedule_d__incurred_amount",
     )
-
-    def SCHEDULE_CLAUSE(self):  # noqa: N802
-        return Case(
-            When(schedule_a__isnull=False, then=Schedule.A.value),
-            When(schedule_b__isnull=False, then=Schedule.B.value),
-            When(schedule_c__isnull=False, then=Schedule.C.value),
-            When(schedule_c1__isnull=False, then=Schedule.C1.value),
-            When(schedule_c2__isnull=False, then=Schedule.C2.value),
-            When(schedule_d__isnull=False, then=Schedule.D.value),
-            When(schedule_e__isnull=False, then=Schedule.E.value),
-            When(schedule_f__isnull=False, then=Schedule.F.value),
-        )
 
     BACK_REFERENCE_CLAUSE = Coalesce(
         F("reatt_redes__transaction_id"),
@@ -169,6 +352,18 @@ class TransactionManager(SoftDeleteManager):
         default=F("_form_type"),
         output_field=TextField(),
     )
+
+    def SCHEDULE_CLAUSE(self):  # noqa: N802
+        return Case(
+            When(schedule_a__isnull=False, then=Schedule.A.value),
+            When(schedule_b__isnull=False, then=Schedule.B.value),
+            When(schedule_c__isnull=False, then=Schedule.C.value),
+            When(schedule_c1__isnull=False, then=Schedule.C1.value),
+            When(schedule_c2__isnull=False, then=Schedule.C2.value),
+            When(schedule_d__isnull=False, then=Schedule.D.value),
+            When(schedule_e__isnull=False, then=Schedule.E.value),
+            When(schedule_f__isnull=False, then=Schedule.F.value),
+        )
 
     def REPORT_CODE_LABEL_CLAUSE(self):
         return Subquery(  # noqa: N806
@@ -221,6 +416,22 @@ class TransactionManager(SoftDeleteManager):
             output_field=TextField(),
         )
 
+    def LINE_LABEL_CLAUSE(self):  # noqa: N802
+        label_map = {
+            **line_labels_a,
+            **line_labels_b,
+            **line_labels_c,
+            **line_labels_d,
+            **line_labels_e,
+            **line_labels_f,
+        }
+        return Case(
+            *[
+                When(form_type=line, then=Value(label))
+                for line, label in label_map.items()
+            ]
+        )
+
     A_11 = ["SA11A", "SA11AI", "SA11AII", "SA11B", "SA11C"]
     A = ["SA12", "SA13", "SA14", "SA15", "SA16", "SA17"]
     B = [
@@ -240,21 +451,27 @@ class TransactionManager(SoftDeleteManager):
     E = ["SE"]
     F = ["SF"]
 
-    def LINE_LABEL_CLAUSE(self):  # noqa: N802
-        label_map = {
-            **line_labels_a,
-            **line_labels_b,
-            **line_labels_c,
-            **line_labels_d,
-            **line_labels_e,
-            **line_labels_f,
-        }
-        return Case(
-            *[
-                When(form_type=line, then=Value(label))
-                for line, label in label_map.items()
-            ]
-        )
+    DATE_MAPPING = {
+        "A": ["schedule_a__contribution_date"],
+        "B": ["schedule_b__expenditure_date"],
+        "C": ["schedule_c__loan_incurred_date"],
+        "C1": [],
+        "C2": [],
+        "D": [],
+        "E": ["schedule_e__disbursement_date", "schedule_e__dissemination_date"],
+        "F": ["schedule_f__expenditure_date"],
+    }
+
+    AMOUNT_MAPPING = {
+        "A": ["schedule_a__contribution_amount"],
+        "B": ["schedule_b__expenditure_amount"],
+        "C": ["schedule_c__loan_amount"],
+        "C1": [],
+        "C2": ["schedule_c2__guaranteed_amount"],
+        "D": ["schedule_d__incurred_amount"],
+        "E": ["schedule_e__expenditure_amount"],
+        "F": ["schedule_f__expenditure_amount"],
+    }
 
 
 class Schedule(Enum):

--- a/django-backend/fecfiler/transactions/serializers.py
+++ b/django-backend/fecfiler/transactions/serializers.py
@@ -13,7 +13,7 @@ from rest_framework.serializers import (
     CharField,
     DateField,
     DecimalField,
-    PrimaryKeyRelatedField,
+    ListField,
 )
 from fecfiler.transactions.models import Transaction
 from fecfiler.transactions.schedule_a.serializers import ScheduleASerializer
@@ -370,7 +370,7 @@ class TransactionListSerializer(ModelSerializer):
     aggregate = DecimalField(max_digits=11, decimal_places=2, read_only=True)
     report_code_label = CharField(read_only=True)
     report_type = CharField(read_only=True)
-    report_ids = PrimaryKeyRelatedField(many=True, read_only=True, source="reports")
+    report_ids = ListField(child=UUIDField(), read_only=True, source="report_ids_list")
     loan_agreement_id = UUIDField(read_only=True, allow_null=True)
 
     class Meta:
@@ -399,7 +399,6 @@ class TransactionListSerializer(ModelSerializer):
             "debt_id",
             "force_itemized",
             "loan_agreement_id",
-            "form_type",
         ]
 
 

--- a/django-backend/fecfiler/transactions/tests/test_views.py
+++ b/django-backend/fecfiler/transactions/tests/test_views.py
@@ -241,7 +241,7 @@ class TransactionViewsTestCase(FecfilerViewSetTest):
         view_set.request = self.post_request({}, {"schedules": "A,B,D,E"})
         self.assertEqual(view_set.get_queryset().count(), 11)
         view_set.request = self.post_request({}, {"schedules": ""})
-        self.assertEqual(view_set.get_queryset().count(), 0)
+        self.assertEqual(view_set.get_queryset().count(), 13)
 
     def test_get_previous_entity(self):
         view_set = TransactionViewSet()

--- a/django-backend/fecfiler/transactions/views.py
+++ b/django-backend/fecfiler/transactions/views.py
@@ -102,7 +102,7 @@ class TransactionViewSet(CommitteeOwnedViewMixin, ModelViewSet):
             return TransactionListSerializer
         return TransactionSerializer
 
-    def get_queryset(self):
+    def get_detail_queryset(self):
         queryset = super().get_queryset()
         report_id = (
             (
@@ -113,20 +113,41 @@ class TransactionViewSet(CommitteeOwnedViewMixin, ModelViewSet):
             else None
         )
         queryset = queryset.filter(reports__id=report_id) if report_id else queryset
+        return queryset
 
+    def get_queryset(self):
+        report_type = self.request.query_params.get("report_type")
+        report_code_label = self.request.query_params.get("report_code_label")
         schedule_filters = self.request.query_params.get("schedules")
-        if schedule_filters is not None:
-            schedules_to_include = schedule_filters.split(",") if schedule_filters else []
+        schedules_to_include = schedule_filters.split(",") if schedule_filters else []
+
+        queryset = Transaction.objects.get_list_queryset(
+            schedules_to_include, report_type, report_code_label
+        )
+
+        report_id = (
+            (
+                self.request.query_params.get("report_id")
+                or self.request.data.get("report_id")
+            )
+            if self.request
+            else None
+        )
+        queryset = queryset.filter(reports__id=report_id) if report_id else queryset
+
+        if schedules_to_include:
             queryset = queryset.filter(
                 schedule__in=[
                     Schedule[schedule].value for schedule in schedules_to_include
                 ]
             )
 
+        # Guarantors
         parent_id = self.request.query_params.get("parent")
         if parent_id:
             queryset = queryset.filter(parent_transaction_id=parent_id)
 
+        # List of transactions by contact
         contact_id = self.request.query_params.get("contact")
         if contact_id:
             queryset = queryset.filter(
@@ -137,7 +158,7 @@ class TransactionViewSet(CommitteeOwnedViewMixin, ModelViewSet):
                 | Q(contact_5=contact_id)
             )
 
-        return queryset.prefetch_related("reports")
+        return queryset
 
     def create(self, request, *args, **kwargs):
         with db_transaction.atomic():
@@ -600,7 +621,7 @@ class TransactionViewSet(CommitteeOwnedViewMixin, ModelViewSet):
                 original_state = original_contact_2.candidate_state
 
                 next_transactions_by_election = (
-                    self.get_queryset()
+                    self.get_detail_queryset()
                     .filter(
                         ~Q(id=original_instance.id),
                         Q(
@@ -699,7 +720,7 @@ class TransactionViewSet(CommitteeOwnedViewMixin, ModelViewSet):
         # Handle date leap-frogging just for Schedule F transactions
         if original_contact_2 is not None and original_election_year:
             leapfrogged_sch_f_transactions = (
-                self.get_queryset()
+                self.get_detail_queryset()
                 .filter(
                     ~Q(id=original_instance.id),
                     Q(
@@ -755,7 +776,7 @@ class TransactionViewSet(CommitteeOwnedViewMixin, ModelViewSet):
             != transaction_instance.schedule_f.general_election_year  # noqa: E501
         ):
             leapfrogged_sch_f_transactions = (
-                self.get_queryset()
+                self.get_detail_queryset()
                 .filter(
                     ~Q(id=original_instance.id),
                     Q(


### PR DESCRIPTION
Issue [FECFILE-2816](https://fecgov.atlassian.net/browse/FECFILE-2816)
APP [PR3513](https://github.com/fecgov/fecfile-web-app/pull/3513)

Pulled in the changes to [FECFILE-2547](https://fecgov.atlassian.net/browse/FECFILE-2547) as it had some of the framework set up that I was going to build upon for this ticket.

This split the View/Manager/Serializer between the list and the detail version of Transactions. For the List there's a lot of things we don't require that can save us a lot of extra queries and joins. Was able to completely get rid of the report query, and for the two remaining queries, they went from 15 and 21 joins respectively to 6 - 10 each (depending on which schedules are requested).

One of the fixes was to reduce the joins to only the schedules requested, since for the trransaction list page we make 3 API calls, separated by schedule. This significantly helps reduce the joins for those. (Doesn't really help out for the list of transactions for a contact since that will be all schedules). We also reduce calls for parent transactions.

All in all it significantly reduces query time, though it does spend a little longer in django preparing the queries, but it is consistently faster overall.