### PR TITLE
2861 - Update django to 5.2.11 for critical security vulnerability

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ django-cors-headers==4.7.0
 django-deprecate-fields==0.2.1
 django-migration-linter==5.2.0
 django-structlog==9.1.1
-Django==5.2.9
+Django==5.2.11
 djangorestframework==3.16.0
 drf-spectacular==0.28.0
 Faker==37.6.0


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-2861
Follow-up: https://fecgov.atlassian.net/browse/FOSEC-97
  
https://docs.djangoproject.com/en/6.0/releases/5.2.10/
https://docs.djangoproject.com/en/6.0/releases/5.2.11/