### PR TITLE
backfill Test into dev

### DIFF
--- a/manifests/manifest-test.yml
+++ b/manifests/manifest-test.yml
@@ -44,7 +44,7 @@ defaults: &defaults
 applications:
   - name: fecfile-web-api
     <<: *defaults
-    instances: 4
+    instances: 2
     routes:
       - route: fecfile-web-api-test.apps.internal
     command: bin/run-api.sh


### PR DESCRIPTION
Number of test instances lowered due to too many connections being allocated.  we can increase the size of the test db if we'd like to go back up to 4