### PR TITLE
Patch/avoid overriding debt values

### DIFF
--- a/django-backend/fecfiler/transactions/views.py
+++ b/django-backend/fecfiler/transactions/views.py
@@ -527,17 +527,12 @@ class TransactionViewSet(CommitteeOwnedViewMixin, ModelViewSet):
                 if transaction_instance.schedule_d and report.coverage_from_date:
                     coverage_from_date = report.coverage_from_date
 
-            if coverage_through_date or coverage_from_date:
-                if coverage_through_date:
-                    schedule_instance.report_coverage_through_date = coverage_through_date
-                if coverage_from_date:
-                    schedule_instance.report_coverage_from_date = coverage_from_date
-                schedule_instance.save(
-                    update_fields=[
-                        "report_coverage_through_date",
-                        "report_coverage_from_date",
-                    ]
-                )
+            if coverage_through_date:
+                schedule_instance.report_coverage_through_date = coverage_through_date
+                schedule_instance.save(update_fields=["report_coverage_through_date"])
+            elif coverage_from_date:
+                schedule_instance.report_coverage_from_date = coverage_from_date
+                schedule_instance.save(update_fields=["report_coverage_from_date"])
 
         Report.objects.filter(committee_account_id=committee_id).update(
             calculation_status=None


### PR DESCRIPTION
Because the debt values like beginning_balance and payment_amount were getting saved to the schedule_d before we were updating the report coverage dates on the schedule_d, when we got to updating the coverage dates, we were clobbering the money amounts.  Changes the coverage date updates to only update the targeted field so it's ok that the instance being saved is a bit stale