### PR TITLE
Feature/3012 - Only set CORS headers in the API for local development

### DIFF
--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -10,7 +10,6 @@ import sys
 
 from enum import Enum
 from .env import env
-from corsheaders.defaults import default_headers
 from fecfiler.shared.utilities import get_float_from_string, get_boolean_from_string
 from fecfiler.web_services.profilers import WEB_SERVICES_PROFILING
 from math import floor
@@ -83,7 +82,6 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "rest_framework",
     "drf_spectacular",
-    "corsheaders",
     "django_structlog",
     "django_migration_linter",
     "fecfiler.committee_accounts",
@@ -131,7 +129,6 @@ if INCLUDE_SILK:
 
 
 MIDDLEWARE += [
-    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "fecfiler.middleware.HeaderMiddleware",
     "fecfiler.oidc.middleware.TimeoutMiddleware.TimeoutMiddleware",
@@ -160,17 +157,6 @@ TEMPLATES = [
         },
     },
 ]
-
-CORS_ALLOWED_ORIGIN_REGEXES = [r"https://(.*?)fecfile\.fec\.gov$"]
-
-CORS_ALLOW_HEADERS = (
-    *default_headers,
-    "enctype",
-    "token",
-    "cache-control",
-)
-
-CORS_ALLOW_CREDENTIALS = True
 
 # In cloud environemnt, name will be from VCAP_APPLICATION
 # - otherwise from DJANGO_APPLICATION which we set in docker-compose.yml

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -10,6 +10,7 @@ import sys
 
 from enum import Enum
 from .env import env
+from corsheaders.defaults import default_headers
 from fecfiler.shared.utilities import get_float_from_string, get_boolean_from_string
 from fecfiler.web_services.profilers import WEB_SERVICES_PROFILING
 from math import floor
@@ -82,6 +83,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "rest_framework",
     "drf_spectacular",
+    "corsheaders",
     "django_structlog",
     "django_migration_linter",
     "fecfiler.committee_accounts",
@@ -129,6 +131,7 @@ if INCLUDE_SILK:
 
 
 MIDDLEWARE += [
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "fecfiler.middleware.HeaderMiddleware",
     "fecfiler.oidc.middleware.TimeoutMiddleware.TimeoutMiddleware",
@@ -157,6 +160,17 @@ TEMPLATES = [
         },
     },
 ]
+
+CORS_ALLOWED_ORIGIN_REGEXES = [r"https://(.*?)fecfile\.fec\.gov$"]
+
+CORS_ALLOW_HEADERS = (
+    *default_headers,
+    "enctype",
+    "token",
+    "cache-control",
+)
+
+CORS_ALLOW_CREDENTIALS = True
 
 # In cloud environemnt, name will be from VCAP_APPLICATION
 # - otherwise from DJANGO_APPLICATION which we set in docker-compose.yml

--- a/django-backend/fecfiler/settings/base.py
+++ b/django-backend/fecfiler/settings/base.py
@@ -163,15 +163,6 @@ TEMPLATES = [
 
 CORS_ALLOWED_ORIGIN_REGEXES = [r"https://(.*?)fecfile\.fec\.gov$"]
 
-CORS_ALLOW_HEADERS = (
-    *default_headers,
-    "enctype",
-    "token",
-    "cache-control",
-)
-
-CORS_ALLOW_CREDENTIALS = True
-
 # In cloud environemnt, name will be from VCAP_APPLICATION
 # - otherwise from DJANGO_APPLICATION which we set in docker-compose.yml
 APPLICATION_NAME = env.name or env.get_credential("DJANGO_APPLICATION", "FECFILE")

--- a/django-backend/fecfiler/settings/local.py
+++ b/django-backend/fecfiler/settings/local.py
@@ -1,9 +1,22 @@
 from .base import *  # NOSONAR # noqa: F401, F403
+from corsheaders.defaults import default_headers
 
 # These settings are for local development only.
 
-CORS_ALLOWED_ORIGIN_REGEXES.append("http://localhost:4200")  # NOSONAR # noqa: F405
-CSRF_TRUSTED_ORIGINS.append("http://localhost:4200")  # NOSONAR # noqa: F405
+INSTALLED_APPS.append("corsheaders")
+MIDDLEWARE.append("corsheaders.middleware.CorsMiddleware")
+
+CORS_ALLOWED_ORIGIN_REGEXES = ["http://localhost:4200"]  # NOSONAR # noqa: F405
+CSRF_TRUSTED_ORIGINS = ["http://localhost:4200"]  # NOSONAR # noqa: F405
+
+CORS_ALLOW_HEADERS = (
+    *default_headers,
+    "enctype",
+    "token",
+    "cache-control",
+)
+
+CORS_ALLOW_CREDENTIALS = True
 
 try:
     from .local import *  # NOSONAR # noqa: F401, F403

--- a/django-backend/fecfiler/settings/local.py
+++ b/django-backend/fecfiler/settings/local.py
@@ -1,22 +1,9 @@
 from .base import *  # NOSONAR # noqa: F401, F403
-from corsheaders.defaults import default_headers
 
 # These settings are for local development only.
 
-INSTALLED_APPS.append("corsheaders")
-MIDDLEWARE.append("corsheaders.middleware.CorsMiddleware")
-
-CORS_ALLOWED_ORIGIN_REGEXES = ["http://localhost:4200"]  # NOSONAR # noqa: F405
-CSRF_TRUSTED_ORIGINS = ["http://localhost:4200"]  # NOSONAR # noqa: F405
-
-CORS_ALLOW_HEADERS = (
-    *default_headers,
-    "enctype",
-    "token",
-    "cache-control",
-)
-
-CORS_ALLOW_CREDENTIALS = True
+CORS_ALLOWED_ORIGIN_REGEXES.append("http://localhost:4200")  # NOSONAR # noqa: F405
+CSRF_TRUSTED_ORIGINS.append("http://localhost:4200")  # NOSONAR # noqa: F405
 
 try:
     from .local import *  # NOSONAR # noqa: F401, F403

--- a/django-backend/fecfiler/settings/local.py
+++ b/django-backend/fecfiler/settings/local.py
@@ -3,11 +3,11 @@ from corsheaders.defaults import default_headers
 
 # These settings are for local development only.
 
-INSTALLED_APPS.append("corsheaders")
-MIDDLEWARE.append("corsheaders.middleware.CorsMiddleware")
+INSTALLED_APPS.append("corsheaders")  # NOSONAR # noqa: F405
+MIDDLEWARE.append("corsheaders.middleware.CorsMiddleware")  # NOSONAR # noqa: F405
 
-CORS_ALLOWED_ORIGIN_REGEXES = ["http://localhost:4200"]  # NOSONAR # noqa: F405
-CSRF_TRUSTED_ORIGINS = ["http://localhost:4200"]  # NOSONAR # noqa: F405
+CORS_ALLOWED_ORIGIN_REGEXES = ["http://localhost:4200"]
+CSRF_TRUSTED_ORIGINS = ["http://localhost:4200"]
 
 CORS_ALLOW_HEADERS = (
     *default_headers,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ celery==5.4.0
 cfenv==0.5.3
 cryptography==46.0.7
 dj_database_url==2.3.0
-django-cors-headers==4.9.0
 django-deprecate-fields==0.2.3
 django-migration-linter==5.2.0
 django-structlog==9.1.1


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-3012
  
Related PRs: [API](https://github.com/fecgov/fecfile-web-api/pull/2023), [Proxy](https://github.com/fecgov/fecfile-api-proxy/pull/49)
