### PR TITLE
[Sprint 88]Feature/2737 - update compose_transaction queries

### DIFF
--- a/django-backend/fecfiler/transactions/itemization.py
+++ b/django-backend/fecfiler/transactions/itemization.py
@@ -33,8 +33,9 @@ A_B_OVER_TWO_HUNDRED_TYPES = (
 
 class CascadeDirection(Enum):
     """Direction for cascading itemization changes."""
-    TO_PARENTS = 'up'
-    TO_CHILDREN = 'down'
+
+    TO_PARENTS = "up"
+    TO_CHILDREN = "down"
 
 
 def has_itemized_children(transaction) -> bool:
@@ -47,12 +48,12 @@ def has_itemized_children(transaction) -> bool:
     Returns:
         Boolean indicating if any children are itemized
     """
+    if hasattr(transaction, "has_cached_itemized_children"):
+        return transaction.has_cached_itemized_children
     transaction_model = transaction.__class__
 
     return transaction_model.objects.filter(
-        parent_transaction_id=transaction.id,
-        deleted__isnull=True,
-        itemized=True
+        parent_transaction_id=transaction.id, deleted__isnull=True, itemized=True
     ).exists()
 
 
@@ -127,9 +128,7 @@ def get_all_parent_ids(transaction) -> List[UUID]:
 
 
 def _cascade_itemization_generic(
-    transaction,
-    direction: CascadeDirection,
-    should_be_itemized: bool
+    transaction, direction: CascadeDirection, should_be_itemized: bool
 ) -> None:
     """
     Generic cascade function for itemization changes.
@@ -147,7 +146,8 @@ def _cascade_itemization_generic(
 
     # Get related transaction IDs
     related_ids = (
-        get_all_parent_ids(transaction) if direction == CascadeDirection.TO_PARENTS
+        get_all_parent_ids(transaction)
+        if direction == CascadeDirection.TO_PARENTS
         else get_all_children_ids(transaction.id)
     )
 
@@ -157,8 +157,7 @@ def _cascade_itemization_generic(
     # Build query for transactions that need updating
     transaction_model = transaction.__class__
     base_query = transaction_model.objects.filter(
-        id__in=related_ids,
-        deleted__isnull=True
+        id__in=related_ids, deleted__isnull=True
     )
 
     # Only include transactions that need updating (different from target state)

--- a/django-backend/fecfiler/web_services/dot_fec/dot_fec_composer.py
+++ b/django-backend/fecfiler/web_services/dot_fec/dot_fec_composer.py
@@ -15,6 +15,7 @@ from fecfiler.transactions.schedule_d.utils import add_schedule_d_contact_fields
 from fecfiler.transactions.schedule_e.utils import add_schedule_e_contact_fields
 from fecfiler.transactions.schedule_f.utils import add_schedule_f_contact_fields
 from fecfiler.transactions.itemization import calculate_itemization
+from django.db.models import Exists, OuterRef
 import structlog
 
 logger = structlog.get_logger(__name__)
@@ -70,11 +71,16 @@ def compose_transaction(transaction: Transaction):
 def compose_transactions(report_id):
     report = Report.objects.select_related("committee_account").get(id=report_id)
 
+    itemized_children_subquery = Transaction.objects.filter(
+        parent_transaction_id=OuterRef("id"), deleted__isnull=True, itemized=True
+    )
+
     transactions_queryset = (
         Transaction.objects.filter(
             reports__id=report_id,
             committee_account__id=report.committee_account.id,
         )
+        .annotate(has_cached_itemized_children=Exists(itemized_children_subquery))
         .select_related("contact_1")
         .prefetch_related(
             "schedule_a",
@@ -96,8 +102,6 @@ def compose_transactions(report_id):
         logger.info(f"composing transactions: {report_id}")
         """Compose derived fields"""
 
-        transactions = prefetch_itemization(transactions)
-
         for transaction in transactions:
             compose_transaction(transaction)
 
@@ -106,21 +110,6 @@ def compose_transactions(report_id):
     else:
         logger.info(f"no transactions found for report: {report_id}")
         return []
-
-
-def prefetch_itemization(transactions):
-    parent_ids = [t.id for t in transactions]
-    child_records = Transaction.objects.filter(
-        parent_transaction_id__in=parent_ids, deleted__isnull=True, itemized=True
-    ).values("id", "parent_transaction_id")
-    parents_with_itemized_children = {
-        row["parent_transaction_id"] for row in child_records
-    }
-    for transaction in transactions:
-        transaction.has_cached_itemized_children = (
-            transaction.id in parents_with_itemized_children
-        )
-    return transactions
 
 
 class Header:

--- a/django-backend/fecfiler/web_services/dot_fec/dot_fec_composer.py
+++ b/django-backend/fecfiler/web_services/dot_fec/dot_fec_composer.py
@@ -68,22 +68,59 @@ def compose_transaction(transaction: Transaction):
 
 
 def compose_transactions(report_id):
-    report = Report.objects.get(id=report_id)
-    transactions = Transaction.objects.filter(
-        reports__id=report_id,
-        committee_account__id=report.committee_account.id,
+    report = Report.objects.select_related("committee_account").get(id=report_id)
+
+    transactions_queryset = (
+        Transaction.objects.filter(
+            reports__id=report_id,
+            committee_account__id=report.committee_account.id,
+        )
+        .select_related("contact_1")
+        .prefetch_related(
+            "schedule_a",
+            "schedule_b",
+            "schedule_c",
+            "schedule_c1",
+            "schedule_c2",
+            "schedule_d",
+            "schedule_e",
+            "schedule_f",
+            "contact_2",
+            "contact_3",
+            "contact_4",
+            "contact_5",
+        )
     )
-    if transactions.exists():
+    transactions = list(transactions_queryset)
+    if transactions:
         logger.info(f"composing transactions: {report_id}")
         """Compose derived fields"""
+
+        transactions = prefetch_itemization(transactions)
+
         for transaction in transactions:
             compose_transaction(transaction)
 
         logger.info(f"Composed for {transactions[0].itemized}")
-        return [t for t in transactions if (t.itemized or report.form_24 is not None)]
+        return [t for t in transactions if (t.itemized or report.form_24_id is not None)]
     else:
         logger.info(f"no transactions found for report: {report_id}")
         return []
+
+
+def prefetch_itemization(transactions):
+    parent_ids = [t.id for t in transactions]
+    child_records = Transaction.objects.filter(
+        parent_transaction_id__in=parent_ids, deleted__isnull=True, itemized=True
+    ).values("id", "parent_transaction_id")
+    parents_with_itemized_children = {
+        row["parent_transaction_id"] for row in child_records
+    }
+    for transaction in transactions:
+        transaction.has_cached_itemized_children = (
+            transaction.id in parents_with_itemized_children
+        )
+    return transactions
 
 
 class Header:

--- a/django-backend/fecfiler/web_services/views.py
+++ b/django-backend/fecfiler/web_services/views.py
@@ -18,8 +18,6 @@ from .models import DotFEC, UploadSubmission, WebPrintSubmission, FECSubmissionS
 from fecfiler.reports.models import Report, FORMS_TO_CALCULATE
 from drf_spectacular.utils import extend_schema
 from celery.result import AsyncResult
-from .dot_fec.dot_fec_composer import compose_transactions
-from fecfiler.transactions.serializers import TransactionListSerializer
 import structlog
 
 logger = structlog.get_logger(__name__)
@@ -226,17 +224,6 @@ class WebServicesViewSet(viewsets.ViewSet):
 
         logger.debug(f"submit_to_webprint report {report_id}: {task.status}")
         return Response({"status": "Submit .FEC task created"})
-
-    @action(
-        detail=False,
-        methods=["get"],
-        url_path="dot-fec/compose_transactions/(?P<report_id>[a-z0-9-]+)",
-    )
-    def silky_compose_transactions(self, request, report_id):
-        transactions = compose_transactions(report_id)
-        # serializer = TransactionListSerializer(transactions, many=True)
-        # return Response({"transactions": serializer.data})
-        return Response({"number": f"{len(transactions)}"})
 
     def get_calculation_task(self, request, report_id):
         committee_uuid = request.session["committee_uuid"]

--- a/django-backend/fecfiler/web_services/views.py
+++ b/django-backend/fecfiler/web_services/views.py
@@ -18,6 +18,8 @@ from .models import DotFEC, UploadSubmission, WebPrintSubmission, FECSubmissionS
 from fecfiler.reports.models import Report, FORMS_TO_CALCULATE
 from drf_spectacular.utils import extend_schema
 from celery.result import AsyncResult
+from .dot_fec.dot_fec_composer import compose_transactions
+from fecfiler.transactions.serializers import TransactionListSerializer
 import structlog
 
 logger = structlog.get_logger(__name__)
@@ -130,15 +132,11 @@ class WebServicesViewSet(viewsets.ViewSet):
             and report.upload_submission.fecfile_task_state
             not in [FECSubmissionState.SUCCEEDED, FECSubmissionState.FAILED]
         ):
-            logger.debug(
-                f"""There is already an active upload being generated for report
-                {report_id}: {report.upload_submission.fecfile_task_state}"""
-            )
+            logger.debug(f"""There is already an active upload being generated for report
+                {report_id}: {report.upload_submission.fecfile_task_state}""")
             return Response(
-                {
-                    "status": f"""There is already an active upload
-                     being generated for report {report_id}"""
-                },
+                {"status": f"""There is already an active upload
+                     being generated for report {report_id}"""},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -200,10 +198,8 @@ class WebServicesViewSet(viewsets.ViewSet):
                 {report_id}: {report.webprint_submission.fecfile_task_state}"""
             )
             return Response(
-                {
-                    "status": f"""There is already an active webprint being generated
-                    for report {report_id}"""
-                },
+                {"status": f"""There is already an active webprint being generated
+                    for report {report_id}"""},
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
@@ -230,6 +226,17 @@ class WebServicesViewSet(viewsets.ViewSet):
 
         logger.debug(f"submit_to_webprint report {report_id}: {task.status}")
         return Response({"status": "Submit .FEC task created"})
+
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="dot-fec/compose_transactions/(?P<report_id>[a-z0-9-]+)",
+    )
+    def silky_compose_transactions(self, request, report_id):
+        transactions = compose_transactions(report_id)
+        # serializer = TransactionListSerializer(transactions, many=True)
+        # return Response({"transactions": serializer.data})
+        return Response({"number": f"{len(transactions)}"})
 
     def get_calculation_task(self, request, report_id):
         committee_uuid = request.session["committee_uuid"]


### PR DESCRIPTION
Issue [FECFILE-2737](https://fecgov.atlassian.net/browse/FECFILE-2737)

Changes:

- `select_related("committee_account")` on Report
- `.select_related("contact_1")
        .prefetch_related(
            "schedule_a",
            "schedule_b",
            "schedule_c",
            "schedule_c1",
            "schedule_c2",
            "schedule_d",
            "schedule_e",
            "schedule_f",
            "contact_2",
            "contact_3",
            "contact_4",
            "contact_5",
        )` on Transaction
- convert transactions exist to transactions list
- prefetch_itemization

To test, you can roll back the last commit which removed the test endpoint I used. See ticket for query results