### PR TITLE
removes line in serializer that was overwriting can_unamend value

### DIFF
--- a/django-backend/fecfiler/reports/serializers.py
+++ b/django-backend/fecfiler/reports/serializers.py
@@ -156,7 +156,6 @@ class ReportSerializer(CommitteeOwnedSerializer, FecSchemaValidatorSerializerMix
                     representation[property] = form_1m[property]
 
         representation["can_delete"] = instance.can_delete
-        representation["can_unamend"] = instance.can_unamend
 
         return representation
 

--- a/django-backend/fecfiler/reports/tests/test_views.py
+++ b/django-backend/fecfiler/reports/tests/test_views.py
@@ -306,7 +306,8 @@ class CommitteeMemberViewSetTest(FecfilerViewSetTest):
 
         report.amend()
 
-        # test that a successfully submitted report with no transactions can not be unamended
+        # test that a successfully submitted report
+        # with no transactions can not be unamended
         submission = UploadSubmission.objects.initiate_submission(
             str(report.id),
         )
@@ -330,7 +331,8 @@ class CommitteeMemberViewSetTest(FecfilerViewSetTest):
         self.assertEqual(report_retrieve_response.status_code, 200)
         self.assertEqual(report_retrieve_response.data["can_unamend"], False)
 
-        # now amend the report and add a transaction, which should make the report unable to be unamended
+        # now amend the report and add a transaction,
+        # which should make the report unable to be unamended
         report.amend()
 
         create_schedule_a(

--- a/django-backend/fecfiler/reports/tests/test_views.py
+++ b/django-backend/fecfiler/reports/tests/test_views.py
@@ -207,29 +207,7 @@ class CommitteeMemberViewSetTest(FecfilerViewSetTest):
         )
         self.assertEqual(retrieve_response.status_code, 200)
         self.assertEqual(retrieve_response.data["report_status"], "Submission success")
-        logger.warning(f"how many reports {Report.objects.filter(id=report.id).count()}")
-        request = self.build_viewset_post_request(
-            f"/api/v1/reports/{report.id}/amend",
-            {},
-            {},
-            True,
-            None,
-            committee=committee,
-        )
-        request.query_params = {}
-        view = ReportViewSet()
-        view.request = request
-        view.action = "amend"
-        view.kwargs = {"pk": report.id}
-        report_from_view = view.get_object()
-
-        logger.error(
-            f"test report_from_view id {report_from_view.id} "
-            f"status {report_from_view.report_status}"
-        )
-        report = Report.objects.get(id=report.id)
-        logger.error(f"test report id {report.id} status {report.report_status}")
-        self.assertEqual(report.report_status, STATUS_CODE_SUCCESS)
+        self.assertEqual(retrieve_response.data["can_unamend"], False)
 
         response = self.send_viewset_post_request(
             f"/api/v1/reports/{report.id}/amend",
@@ -240,6 +218,17 @@ class CommitteeMemberViewSetTest(FecfilerViewSetTest):
             pk=report.id,
         )
         self.assertEqual(response.status_code, 200)
+
+        retrieve_response = self.send_viewset_get_request(
+            f"/api/v1/reports/{report.id}",
+            ReportViewSet,
+            "retrieve",
+            committee=committee,
+            pk=report.id,
+        )
+        self.assertEqual(retrieve_response.status_code, 200)
+        self.assertEqual(retrieve_response.data["report_status"], "In progress")
+        self.assertEqual(retrieve_response.data["can_unamend"], True)
 
     def test_unable_to_amend(self):
         """Test that an in progress report cannot be amended,
@@ -259,6 +248,16 @@ class CommitteeMemberViewSetTest(FecfilerViewSetTest):
     def test_unamend(self):
         """Test an amended report can be unamended."""
         report = create_form3x(self.committee, "2024-01-01", "2024-02-01", {})
+        report_retrieve_response = self.send_viewset_get_request(
+            f"/api/v1/reports/{report.id}",
+            ReportViewSet,
+            "retrieve",
+            committee=self.committee,
+            pk=report.id,
+        )
+        self.assertEqual(report_retrieve_response.status_code, 200)
+        self.assertEqual(report_retrieve_response.data["can_unamend"], False)
+
         response = self.send_viewset_post_request(
             f"/api/v1/reports/{report.id}/unamend",
             {},
@@ -285,6 +284,15 @@ class CommitteeMemberViewSetTest(FecfilerViewSetTest):
         )
         report.amend()
 
+        report_retrieve_response = self.send_viewset_get_request(
+            f"/api/v1/reports/{report.id}",
+            ReportViewSet,
+            "retrieve",
+            committee=self.committee,
+            pk=report.id,
+        )
+        self.assertEqual(report_retrieve_response.status_code, 200)
+        self.assertEqual(report_retrieve_response.data["can_unamend"], True)
         response = self.send_viewset_post_request(
             f"/api/v1/reports/{report.id}/unamend",
             {},
@@ -298,6 +306,33 @@ class CommitteeMemberViewSetTest(FecfilerViewSetTest):
 
         report.amend()
 
+        # test that a successfully submitted report with no transactions can not be unamended
+        submission = UploadSubmission.objects.initiate_submission(
+            str(report.id),
+        )
+        submission.save_fec_response(
+            json.dumps(
+                {
+                    "submission_id": "fake_submission_id",
+                    "status": FECStatus.ACCEPTED.value,
+                    "message": "Test Save Response",
+                    "report_id": "1234",
+                }
+            )
+        )
+        report_retrieve_response = self.send_viewset_get_request(
+            f"/api/v1/reports/{report.id}",
+            ReportViewSet,
+            "retrieve",
+            committee=self.committee,
+            pk=report.id,
+        )
+        self.assertEqual(report_retrieve_response.status_code, 200)
+        self.assertEqual(report_retrieve_response.data["can_unamend"], False)
+
+        # now amend the report and add a transaction, which should make the report unable to be unamended
+        report.amend()
+
         create_schedule_a(
             "INDIVIDUAL_RECEIPT",
             self.committee,
@@ -306,6 +341,15 @@ class CommitteeMemberViewSetTest(FecfilerViewSetTest):
             "100.00",
             report=report,
         )
+        report_retrieve_response = self.send_viewset_get_request(
+            f"/api/v1/reports/{report.id}",
+            ReportViewSet,
+            "retrieve",
+            committee=self.committee,
+            pk=report.id,
+        )
+        self.assertEqual(report_retrieve_response.status_code, 200)
+        self.assertEqual(report_retrieve_response.data["can_unamend"], False)
         response = self.send_viewset_post_request(
             f"/api/v1/reports/{report.id}/unamend",
             {},


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-3165
  
Related PRs (previous pr) https://github.com/fecgov/fecfile-web-api/pull/2073

Tests were covering whether or not the action would succeed when the request was made to the api (so the unamend did not actually happen in the breakage).  They were not checking the value coming out of the serializer.  Added tests to assert those values as well.  Specifically this test breaks before the change to the serializer is made:
```
# test that a successfully submitted report with no transactions can not be unamended
        submission = UploadSubmission.objects.initiate_submission(
            str(report.id),
        )
        submission.save_fec_response(
            json.dumps(
                {
                    "submission_id": "fake_submission_id",
                    "status": FECStatus.ACCEPTED.value,
                    "message": "Test Save Response",
                    "report_id": "1234",
                }
            )
        )
        report_retrieve_response = self.send_viewset_get_request(
            f"/api/v1/reports/{report.id}",
            ReportViewSet,
            "retrieve",
            committee=self.committee,
            pk=report.id,
        )
        self.assertEqual(report_retrieve_response.status_code, 200)
        self.assertEqual(report_retrieve_response.data["can_unamend"], False)
```
