### PR TITLE
Block deleting linked contacts via API

### DIFF
--- a/django-backend/fecfiler/contacts/tests/test_views.py
+++ b/django-backend/fecfiler/contacts/tests/test_views.py
@@ -8,6 +8,7 @@ from fecfiler.committee_accounts.models import CommitteeAccount
 from ..views import ContactViewSet, DeletedContactsViewSet
 from .utils import create_test_individual_contact
 from fecfiler.shared.viewset_test import FecfilerViewSetTest
+from fecfiler.transactions.tests.utils import create_schedule_a
 
 CANDIDATE_RESULTS = [
     {"name": "LNAME, FNAME I", "candidate_id": "P60012143", "office_sought": "P"},
@@ -448,6 +449,56 @@ class ContactViewSetTest(FecfilerViewSetTest):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data["first_name"], "Other")
+
+    def test_destroy_unlinked_contact(self):
+        contact = Contact.objects.create(
+            type=Contact.ContactType.INDIVIDUAL,
+            last_name="Last",
+            first_name="First",
+            committee_account_id="11111111-2222-3333-4444-555555555555",
+        )
+
+        response = self.send_viewset_delete_request(
+            f"/api/v1/contacts/{str(contact.id)}/",
+            ContactViewSet,
+            "destroy",
+            pk=contact.id,
+        )
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Contact.objects.filter(id=contact.id).exists())
+        self.assertTrue(
+            Contact.all_objects.filter(id=contact.id, deleted__isnull=False).exists()
+        )
+
+    def test_destroy_linked_contact_returns_409(self):
+        contact = Contact.objects.create(
+            type=Contact.ContactType.INDIVIDUAL,
+            last_name="Last",
+            first_name="First",
+            committee_account_id="11111111-2222-3333-4444-555555555555",
+        )
+        create_schedule_a(
+            "INDIVIDUAL_RECEIPT",
+            self.default_committee,
+            contact,
+            "2026-01-01",
+            "100",
+        )
+
+        response = self.send_viewset_delete_request(
+            f"/api/v1/contacts/{str(contact.id)}/",
+            ContactViewSet,
+            "destroy",
+            pk=contact.id,
+        )
+
+        self.assertEqual(response.status_code, 409)
+        self.assertEqual(
+            response.data,
+            {"detail": "Cannot delete contact linked to transactions or reports."},
+        )
+        self.assertTrue(Contact.objects.filter(id=contact.id).exists())
 
     def test_list_paginated(self):
         for i in range(10):

--- a/django-backend/fecfiler/contacts/views.py
+++ b/django-backend/fecfiler/contacts/views.py
@@ -12,6 +12,8 @@ from rest_framework.response import Response
 from rest_framework.decorators import action
 from rest_framework.viewsets import mixins, GenericViewSet
 from rest_framework import viewsets, pagination, filters, status
+from fecfiler.transactions.models import Transaction
+from fecfiler.reports.models import Form1M
 from .models import Contact
 from .serializers import ContactSerializer
 import fecfiler.settings as settings
@@ -314,6 +316,31 @@ class ContactViewSet(CommitteeOwnedViewMixin, viewsets.ModelViewSet):
     def update(self, request, *args, **kwargs):
         with transaction.atomic():
             return super().update(request, *args, **kwargs)
+
+    def destroy(self, request, *args, **kwargs):
+        contact = self.get_object()
+        has_transaction_or_report = Transaction.objects.filter(
+            Q(contact_1_id=contact.id)
+            | Q(contact_2_id=contact.id)
+            | Q(contact_3_id=contact.id)
+            | Q(contact_4_id=contact.id)
+            | Q(contact_5_id=contact.id)
+        ).exists() or Form1M.objects.filter(
+            Q(contact_affiliated_id=contact.id)
+            | Q(contact_candidate_I_id=contact.id)
+            | Q(contact_candidate_II_id=contact.id)
+            | Q(contact_candidate_III_id=contact.id)
+            | Q(contact_candidate_IV_id=contact.id)
+            | Q(contact_candidate_V_id=contact.id)
+        ).exists()
+
+        if has_transaction_or_report:
+            return Response(
+                {"detail": "Cannot delete contact linked to transactions or reports."},
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        return super().destroy(request, *args, **kwargs)
 
     def get_int_param_value(
         self, request, param_name: str, default_param_value: int, max_param_value: int


### PR DESCRIPTION
This blocks DELETE /api/v1/contacts/:id when the contact is linked to a transaction or Form 1M report reference. Instead of soft deleting, the endpoint now returns 409 with a clear error.

I also added tests for both paths:
- unlinked contact delete still returns 204
- linked contact delete now returns 409 and keeps the contact

Validation run:
- flake8 fecfiler/contacts/views.py fecfiler/contacts/tests/test_views.py

I could not run the Django unit tests in this environment because PostgreSQL is not running and Docker daemon access is unavailable.

Closes #1828