### PR TITLE
use a better cache key for pip install on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           pkg-manager: pip
           app-dir: ~/project/
           cache-key-override: >-
-            pip-{{ .Branch }}{{ checksum 'requirements.txt' }}{{ checksum 'requirements-test.txt' }}
+            pip-{{ .Branch }}{{ checksum 'requirements-all.txt' }}
           pip-dependency-file: requirements-all.txt
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           pkg-manager: pip
           app-dir: ~/project/
           cache-key-override: |
-            pip-{{ checksum "requirements-all.txt" }}
+            pip-{{.Branch}}{{ checksum "requirements-all.txt" }}
           pip-dependency-file: requirements-all.txt
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,8 @@ jobs:
       - python/install-packages:
           pkg-manager: pip
           app-dir: ~/project/
-          cache-key-override: { { checksum 'requirements-all.txt' } }
+          cache-key-override: |
+            pip-{{ checksum "requirements-all.txt" }}
           pip-dependency-file: requirements-all.txt
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,8 @@ jobs:
       - python/install-packages:
           pkg-manager: pip
           app-dir: ~/project/
+          cache-key-override: >-
+            pip-{{ .Branch }}{{ checksum 'requirements.txt' }}{{ checksum 'requirements-test.txt' }}
           pip-dependency-file: requirements-all.txt
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,7 @@ jobs:
       - python/install-packages:
           pkg-manager: pip
           app-dir: ~/project/
-          cache-key-override: >-
-            pip-{{ .Branch }}{{ checksum 'requirements-all.txt' }}
+          cache-key-override: { { checksum 'requirements-all.txt' } }
           pip-dependency-file: requirements-all.txt
 
       - run:


### PR DESCRIPTION
use a new cache key structure
https://circleci.com/developer/orbs/orb/circleci/python
