### PR TITLE
feature/3242 - Switch to allow blank instead of null as front-end sends empty strings for unfilled fields

### DIFF
--- a/django-backend/fecfiler/feedback/serializers.py
+++ b/django-backend/fecfiler/feedback/serializers.py
@@ -7,6 +7,6 @@ logger = structlog.getLogger(__name__)
 
 class FeedbackSerializer(serializers.Serializer):
     action = CharField(max_length=2000)
-    feedback = CharField(max_length=2000, allow_null=True)
-    about = CharField(max_length=2000, allow_null=True)
+    feedback = CharField(max_length=2000, allow_blank=True)
+    about = CharField(max_length=2000, allow_blank=True)
     location = CharField(max_length=2000)

--- a/django-backend/fecfiler/feedback/tests/test_views.py
+++ b/django-backend/fecfiler/feedback/tests/test_views.py
@@ -13,6 +13,7 @@ class FeedbackViewSetTest(FecfilerViewSetTest):
     def setUp(self):
         super().setUp()
 
+    @mock.patch("fecfiler.feedback.views.MOCK_EFO_FILING", False)
     @mock.patch.object(github3, "login", return_value=GitHub)
     @mock.patch.object(GitHub, "repository", return_value=Repository)
     @mock.patch.object(Repository, "create_issue")
@@ -44,6 +45,56 @@ class FeedbackViewSetTest(FecfilerViewSetTest):
         self.assertTrue("&lt;b&gt;test_location&lt;/b&gt;" in body_content)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data, {"status": "feedback submitted"})
+
+    @mock.patch("fecfiler.feedback.views.MOCK_EFO_FILING", False)
+    @mock.patch.object(github3, "login", return_value=GitHub)
+    @mock.patch.object(GitHub, "repository", return_value=Repository)
+    @mock.patch.object(Repository, "create_issue")
+    def test_submit_feedback_limited_data(
+        self, mock_repo_create_issue, mock_github3_repo, mock_github3_login
+    ):
+        response = self.send_viewset_post_request(
+            "/api/v1/feedback/submit/",
+            {
+                "action": "test_action",
+                "feedback": "",
+                "about": "",
+                "location": "<b>test_location</b>",
+            },
+            FeedbackViewSet,
+            "submit_feedback",
+            headers={"HTTP_USER_AGENT": "test_user_agent"},
+        )
+
+        mock_github3_login.assert_called_once()
+        mock_github3_repo.assert_called_once()
+        mock_repo_create_issue.assert_called_once()
+        title, body = mock_repo_create_issue.call_args
+        body_content = body["body"]
+        self.assertEqual("User feedback on &lt;b&gt;test_location&lt;/b&gt;", title[0])
+        self.assertTrue("test_action" in body_content)
+        self.assertTrue("" in body_content)
+        self.assertTrue("" in body_content)
+        self.assertTrue("&lt;b&gt;test_location&lt;/b&gt;" in body_content)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data, {"status": "feedback submitted"})
+
+    def test_submit_feedback_invalid_data(self):
+        response = self.send_viewset_post_request(
+            "/api/v1/feedback/submit/",
+            {
+                "action": "",
+                "feedback": "",
+                "about": "",
+                "location": "<b>test_location</b>",
+            },
+            FeedbackViewSet,
+            "submit_feedback",
+            headers={"HTTP_USER_AGENT": "test_user_agent"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["action"][0], "This field may not be blank.")
 
     @mock.patch("fecfiler.feedback.views.logger")
     def test_csp_report_happy_path(self, mock_logger):

--- a/django-backend/fecfiler/feedback/views.py
+++ b/django-backend/fecfiler/feedback/views.py
@@ -1,11 +1,10 @@
 import github3
 import structlog
-from fecfiler.settings import FECFILE_GITHUB_TOKEN
+from fecfiler.settings import FECFILE_GITHUB_TOKEN, MOCK_EFO_FILING
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from django.utils.html import escape
-
 from .serializers import FeedbackSerializer
 
 logger = structlog.get_logger(__name__)
@@ -42,11 +41,11 @@ class FeedbackViewSet(viewsets.ViewSet):
                 serializer.validated_data["location"],
                 request.META["HTTP_USER_AGENT"],
             )
-
-            client = github3.login(token=FECFILE_GITHUB_TOKEN)
-            client.repository("fecgov", "fecfile-feedback").create_issue(
-                escape(title), body=escape(body)
-            )
+            if not MOCK_EFO_FILING:
+                client = github3.login(token=FECFILE_GITHUB_TOKEN)
+                client.repository("fecgov", "fecfile-feedback").create_issue(
+                    escape(title), body=escape(body)
+                )
 
             return Response({"status": "feedback submitted"})
         except Exception as error:


### PR DESCRIPTION
Issue [FECFILE-3242](https://fecgov.atlassian.net/browse/FECFILE-3242)

APP [PR4169](https://github.com/fecgov/fecfile-web-app/pull/4169)