### PR TITLE
3282 - Add committee ID to log message

### DIFF
--- a/django-backend/fecfiler/committee_accounts/utils/accounts.py
+++ b/django-backend/fecfiler/committee_accounts/utils/accounts.py
@@ -243,7 +243,8 @@ def get_eligible_report_types_processed(committee_data: dict):
 
     if eligible_reports is None:
         logger.error(
-            f"Failed to find eligible reports for processed committee: {committee_key}"
+            f"Failed to find eligible reports for processed committee "
+            f"{committee_data.get('committee_id')}: {committee_key}"
         )
         return fallback_reports
 


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-3282

Test with a presidential committee. Example:
```
2026-07-22 12:27:19 [error    ] Failed to find eligible reports for processed committee C00693234: PP committee_id=None committee_uuid=None ip=172.18.0.1 request_id=7bde3086-386e-4c57-a81e-93ec3a02a9b6 user_id=e100e1da-cbfc-4189-aece-d139048a8e0a
```
  
