### PR TITLE
FECFILE-3275: Stripped space from manifests, added it to docker-compose.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -196,6 +196,7 @@ services:
       FLAG__COMMITTEE_DATA_SOURCE: MOCKED # Values are PRODUCTION, TEST, and MOCKED
       FLAG__ENABLE_IMPORT: True
       FLAG__ENABLE_EMAIL: True
+      SES_FROM_USER: no-reply+local
     deploy:
       resources:
         limits:

--- a/manifests/manifest-dev.yml
+++ b/manifests/manifest-dev.yml
@@ -42,7 +42,6 @@ defaults: &defaults
     FLAG__ENABLE_EMAIL: True
     ENABLE_RESTRICTED_COMMANDS: True
     FEC_FORMAT_VERSION: 8.5
-    SES_FROM_USER: no-reply+dev
 
 applications:
   - name: fecfile-web-api

--- a/manifests/manifest-stage.yml
+++ b/manifests/manifest-stage.yml
@@ -42,7 +42,6 @@ defaults: &defaults
     FLAG__ENABLE_EMAIL: True
     ENABLE_RESTRICTED_COMMANDS: True
     FEC_FORMAT_VERSION: 8.5
-    SES_FROM_USER: no-reply+stage
 
 applications:
   - name: fecfile-web-api

--- a/manifests/manifest-test.yml
+++ b/manifests/manifest-test.yml
@@ -42,7 +42,6 @@ defaults: &defaults
     FLAG__ENABLE_EMAIL: False
     ENABLE_RESTRICTED_COMMANDS: True
     FEC_FORMAT_VERSION: 8.5
-    SES_FROM_USER: no-reply+test
 
 applications:
   - name: fecfile-web-api


### PR DESCRIPTION
Ticket link:
https://fecgov.atlassian.net/browse/FECFILE-3275

Related PRs:
https://github.com/fecgov/fecfile-web-api/pull/2165 (email)

We are using space-specific subdomains so there is no need to specify the space in the username of the From address.
| Space | Before | After |
|--------|--------|--------|
| DEV | no-reply+dev@dev-ses.fecfile.fec.gov | no-reply@dev-ses.fecfile.fec.gov |
| STAGE | no-reply+stage@stage-ses.fecfile.fec.gov | no-reply@stage-ses.fecfile.fec.gov |
| TEST | no-reply+test@test-ses.fecfile.fec.gov | no-reply@test-ses.fecfile.fec.gov |
| PROD | no-reply@fecfile.fec.gov | no-reply@fecfile.fec.gov |
| local | no-reply@dev-ses.fecfile.fec.gov | no-reply+local@dev-ses.fecfile.fec.gov | 