### PR TITLE
[Hold - target sprint 92 due to delayed release] 3181 - Update Django minor version to 5.2.17

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ dj_database_url==2.3.0
 django-deprecate-fields==0.2.3
 django-migration-linter==5.2.0
 django-structlog==9.1.1
-Django==5.2.14
+Django==5.2.17
 djangorestframework==3.17.1
 drf-spectacular==0.29.0
 drf-spectacular-sidecar==2026.4.14


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FECFILE-3181

I went with the latest 5.2.* release - 5.2.17 as of today