### PR TITLE
Hotfix/memo text report serializer committee check

### DIFF
--- a/django-backend/fecfiler/committee_accounts/serializers.py
+++ b/django-backend/fecfiler/committee_accounts/serializers.py
@@ -5,7 +5,6 @@ from rest_framework.serializers import ModelSerializer, ChoiceField, SerializerM
 from drf_spectacular.utils import extend_schema_field
 from drf_spectacular.types import OpenApiTypes
 import structlog
-from fecfiler.validation import serializers
 
 logger = structlog.get_logger(__name__)
 
@@ -83,26 +82,3 @@ class CommitteeMembershipSerializer(CommitteeOwnedSerializer):
     @extend_schema_field(OpenApiTypes.STR)
     def get_email(self, instance):
         return instance.user.email if instance.user else instance.pending_email
-
-
-class ReportCommitteeValidationMixin:
-    """Mixin to validate that report_id belongs to the serializer's committee_account."""
-
-    def validate_report_committee_ownership(self, data):
-        from fecfiler.reports.models import Report
-
-        committee_account = data.get("committee_account")
-        report_id = data.get("report_id")
-        if report_id:
-            exists = Report.objects.filter(
-                id=report_id, committee_account=committee_account
-            ).exists()
-            if not exists:
-                raise serializers.ValidationError(
-                    {
-                        "report_id": (
-                            "Invalid report_id or report does not belong "
-                            "to this committee account."
-                        )
-                    }
-                )

--- a/django-backend/fecfiler/committee_accounts/serializers.py
+++ b/django-backend/fecfiler/committee_accounts/serializers.py
@@ -100,6 +100,9 @@ class ReportCommitteeValidationMixin:
             if not exists:
                 raise serializers.ValidationError(
                     {
-                        "report_id": "Invalid report_id or report does not belong to this committee account."
+                        "report_id": (
+                            "Invalid report_id or report does not belong "
+                            "to this committee account."
+                        )
                     }
                 )

--- a/django-backend/fecfiler/committee_accounts/serializers.py
+++ b/django-backend/fecfiler/committee_accounts/serializers.py
@@ -5,6 +5,7 @@ from rest_framework.serializers import ModelSerializer, ChoiceField, SerializerM
 from drf_spectacular.utils import extend_schema_field
 from drf_spectacular.types import OpenApiTypes
 import structlog
+from fecfiler.validation import serializers
 
 logger = structlog.get_logger(__name__)
 
@@ -82,3 +83,23 @@ class CommitteeMembershipSerializer(CommitteeOwnedSerializer):
     @extend_schema_field(OpenApiTypes.STR)
     def get_email(self, instance):
         return instance.user.email if instance.user else instance.pending_email
+
+
+class ReportCommitteeValidationMixin:
+    """Mixin to validate that report_id belongs to the serializer's committee_account."""
+
+    def validate_report_committee_ownership(self, data):
+        from fecfiler.reports.models import Report
+
+        committee_account = data.get("committee_account")
+        report_id = data.get("report_id")
+        if report_id:
+            exists = Report.objects.filter(
+                id=report_id, committee_account=committee_account
+            ).exists()
+            if not exists:
+                raise serializers.ValidationError(
+                    {
+                        "report_id": "Invalid report_id or report does not belong to this committee account."
+                    }
+                )

--- a/django-backend/fecfiler/memo_text/serializers.py
+++ b/django-backend/fecfiler/memo_text/serializers.py
@@ -2,14 +2,19 @@ from .models import MemoText
 from django.db import transaction
 from fecfiler.validation import serializers
 from rest_framework.serializers import UUIDField, ModelSerializer
-from fecfiler.committee_accounts.serializers import CommitteeOwnedSerializer
+from fecfiler.committee_accounts.serializers import (
+    CommitteeOwnedSerializer,
+    ReportCommitteeValidationMixin,
+)
 import structlog
 
 logger = structlog.get_logger(__name__)
 
 
 class MemoTextSerializer(
-    serializers.FecSchemaValidatorSerializerMixin, CommitteeOwnedSerializer
+    serializers.FecSchemaValidatorSerializerMixin,
+    CommitteeOwnedSerializer,
+    ReportCommitteeValidationMixin,
 ):
     schema_name = "Text"
     report_id = UUIDField(required=True, allow_null=False)
@@ -46,6 +51,9 @@ class MemoTextSerializer(
                 "back_reference_tran_id_number",
             ],
         )
+
+        self.validate_report_committee_ownership(data)
+
         return super().validate(data)
 
 

--- a/django-backend/fecfiler/memo_text/serializers.py
+++ b/django-backend/fecfiler/memo_text/serializers.py
@@ -2,10 +2,8 @@ from .models import MemoText
 from django.db import transaction
 from fecfiler.validation import serializers
 from rest_framework.serializers import UUIDField, ModelSerializer
-from fecfiler.committee_accounts.serializers import (
-    CommitteeOwnedSerializer,
-    ReportCommitteeValidationMixin,
-)
+from fecfiler.committee_accounts.serializers import CommitteeOwnedSerializer
+from fecfiler.reports.serializers import ReportCommitteeValidationMixin
 import structlog
 
 logger = structlog.get_logger(__name__)
@@ -88,3 +86,20 @@ class LinkedMemoTextSerializerMixin(ModelSerializer):
             memo_object = MemoText.objects.get(id=memo_text_id)
             memo_object.delete()
             validated_data["memo_text_id"] = None
+
+    def validate_memo_text_committee_ownership(self, data):
+        committee_account = data.get("committee_account")
+        id = data.get("memo_text_id")
+        if id:
+            exists = MemoText.objects.filter(
+                id=id, committee_account=committee_account
+            ).exists()
+            if not exists:
+                raise serializers.ValidationError(
+                    {
+                        "memo_text_id": (
+                            "Invalid memo_text_id or memo text does not belong "
+                            "to this committee account."
+                        )
+                    }
+                )

--- a/django-backend/fecfiler/memo_text/tests/test_views.py
+++ b/django-backend/fecfiler/memo_text/tests/test_views.py
@@ -50,6 +50,7 @@ class MemoTextViewSetTest(FecfilerViewSetTest):
             data,
             MemoTextViewSet,
             "create",
+            committee=self.committee,
         )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data["text4000"], "test_new_text")
@@ -68,6 +69,7 @@ class MemoTextViewSetTest(FecfilerViewSetTest):
             data,
             MemoTextViewSet,
             "create",
+            committee=self.committee,
         )
         self.assertEqual(response.status_code, 201)
         self.assertEqual(response.data["text4000"], "test_existing_text")
@@ -76,9 +78,10 @@ class MemoTextViewSetTest(FecfilerViewSetTest):
             f"/api/v1/memo-text/?report_id={self.q1_report.id}",
             MemoTextViewSet,
             "list",
+            committee=self.committee,
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data), 1)
+        self.assertEqual(len(response.data), 2)
 
     def test_cannot_get_other_committee_memos(self):
         committee2 = CommitteeAccount.objects.create(committee_id="C00000001")

--- a/django-backend/fecfiler/memo_text/tests/test_views.py
+++ b/django-backend/fecfiler/memo_text/tests/test_views.py
@@ -93,3 +93,72 @@ class MemoTextViewSetTest(FecfilerViewSetTest):
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 0)
+
+    def test_cannot_create_other_committee_memo(self):
+        other_committee = CommitteeAccount.objects.create(committee_id="C00000001")
+        other_committee_report = create_form3x(
+            other_committee, "2024-01-01", "2024-02-01", {}
+        )
+        data = {
+            "report_id": str(other_committee_report.id),
+            "rec_type": "TEXT",
+            "text4000": "test_new_text",
+            "committee_account": str(other_committee.id),
+            "transaction_id_number": "id_number",
+            "transaction_uuid": None,
+            "fields_to_validate": [
+                "report_id",
+                "rec_type",
+                "text4000",
+                "committee_account",
+                "transaction_id_number",
+                "transaction_uuid",
+            ],
+        }
+        response = self.send_viewset_post_request(
+            "/api/v1/memo-text/",
+            data,
+            MemoTextViewSet,
+            "create",
+            committee=self.committee,
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_cannot_update_other_committee_memo(self):
+        other_committee = CommitteeAccount.objects.create(committee_id="C00000001")
+        other_committee_report = create_form3x(
+            other_committee, "2024-01-01", "2024-02-01", {}
+        )
+        data = {
+            "report_id": str(other_committee_report.id),
+            "rec_type": "TEXT",
+            "text4000": "test_new_text",
+            "committee_account": str(other_committee.id),
+            "transaction_id_number": "id_number",
+            "transaction_uuid": None,
+            "fields_to_validate": [
+                "report_id",
+                "rec_type",
+                "text4000",
+                "committee_account",
+                "transaction_id_number",
+                "transaction_uuid",
+            ],
+        }
+        response = self.send_viewset_post_request(
+            "/api/v1/memo-text/",
+            data,
+            MemoTextViewSet,
+            "create",
+            committee=other_committee,
+        )
+        self.assertEqual(response.status_code, 201)
+
+        response = self.send_viewset_put_request(
+            "/api/v1/memo-text/",
+            data,
+            MemoTextViewSet,
+            "update",
+            committee=self.committee,
+        )
+        self.assertEqual(response.status_code, 500)

--- a/django-backend/fecfiler/reports/serializers.py
+++ b/django-backend/fecfiler/reports/serializers.py
@@ -222,3 +222,20 @@ class ReportCommitteeValidationMixin:
                         )
                     }
                 )
+
+        report_ids = data.get("report_ids", [])
+        if report_ids:
+            unique_ids = set(str(rid) for rid in report_ids) if report_ids else set()
+            valid_count = Report.objects.filter(
+                id__in=unique_ids, committee_account=committee_account
+            ).count()
+
+            if valid_count != len(unique_ids):
+                raise ValidationError(
+                    {
+                        "report_ids": (
+                            "One or more report_ids are invalid or do not belong "
+                            "to this committee account."
+                        )
+                    }
+                )

--- a/django-backend/fecfiler/reports/serializers.py
+++ b/django-backend/fecfiler/reports/serializers.py
@@ -199,3 +199,26 @@ class ReportSerializer(CommitteeOwnedSerializer, FecSchemaValidatorSerializerMix
     def get_report_status(self, instance):
         status_code = getattr(instance, "report_status", STATUS_CODE_IN_PROGRESS)
         return REPORT_STATUS_MAP.get(status_code, "In progress")
+
+
+class ReportCommitteeValidationMixin:
+    """Mixin to validate that report_id belongs to the serializer's committee_account."""
+
+    def validate_report_committee_ownership(self, data):
+        from fecfiler.reports.models import Report
+
+        committee_account = data.get("committee_account")
+        report_id = data.get("report_id")
+        if report_id:
+            exists = Report.objects.filter(
+                id=report_id, committee_account=committee_account
+            ).exists()
+            if not exists:
+                raise ValidationError(
+                    {
+                        "report_id": (
+                            "Invalid report_id or report does not belong "
+                            "to this committee account."
+                        )
+                    }
+                )

--- a/django-backend/fecfiler/transactions/models.py
+++ b/django-backend/fecfiler/transactions/models.py
@@ -713,21 +713,6 @@ class Transaction(SoftDeleteModel, CommitteeOwnedModel):
 
     def set_reports(self, report_ids):
         Report = apps.get_model("reports.Report")
-        input_report_ids = set(str(rid) for rid in report_ids) if report_ids else set()
-        if input_report_ids:
-            valid_report_ids = set(
-                str(rid)
-                for rid in Report.objects.filter(
-                    id__in=input_report_ids,
-                    committee_account=self.committee_account,
-                ).values_list("id", flat=True)
-            )
-            if valid_report_ids != input_report_ids:
-                raise SuspiciousSession("request ids don't match")
-            report_ids = valid_report_ids
-        else:
-            report_ids = set()
-
         current_report_ids = set()
         current_report_id_dicts = list(self.reports.values("id"))
         for report_id_dict in current_report_id_dicts:

--- a/django-backend/fecfiler/transactions/models.py
+++ b/django-backend/fecfiler/transactions/models.py
@@ -27,7 +27,6 @@ from fecfiler.transactions.schedule_d.models import ScheduleD
 from fecfiler.transactions.schedule_e.models import ScheduleE
 from fecfiler.transactions.schedule_f.models import ScheduleF
 from fecfiler.contacts.models import Contact
-from django.contrib.sessions.exceptions import SuspiciousSession
 
 import uuid
 import structlog

--- a/django-backend/fecfiler/transactions/serializers.py
+++ b/django-backend/fecfiler/transactions/serializers.py
@@ -277,6 +277,8 @@ class TransactionSerializer(
                 "beneficiary_candidate_state",
             ],
         )
+
+        self.validate_memo_text_committee_ownership(data)
         super().validate(data_to_validate)
         return data
 

--- a/django-backend/fecfiler/transactions/serializers.py
+++ b/django-backend/fecfiler/transactions/serializers.py
@@ -2,7 +2,7 @@ from django.db.models import Sum
 from fecfiler.committee_accounts.serializers import CommitteeOwnedSerializer
 from fecfiler.memo_text.serializers import LinkedMemoTextSerializerMixin
 from fecfiler.validation.serializers import FecSchemaValidatorSerializerMixin
-from fecfiler.reports.serializers import ReportSerializer
+from fecfiler.reports.serializers import ReportCommitteeValidationMixin, ReportSerializer
 from fecfiler.contacts.serializers import ContactSerializer
 from rest_framework.exceptions import ValidationError
 from rest_framework.serializers import empty, ModelSerializer
@@ -61,6 +61,7 @@ class TransactionSerializer(
     LinkedMemoTextSerializerMixin,
     FecSchemaValidatorSerializerMixin,
     CommitteeOwnedSerializer,
+    ReportCommitteeValidationMixin
 ):
     """id must be explicitly configured in order to have it in validated_data
     https://github.com/encode/django-rest-framework/issues/2320#issuecomment-67502474"""
@@ -278,6 +279,7 @@ class TransactionSerializer(
             ],
         )
 
+        self.validate_report_committee_ownership(initial_data)
         self.validate_memo_text_committee_ownership(data)
         super().validate(data_to_validate)
         return data

--- a/django-backend/fecfiler/transactions/tests/test_views.py
+++ b/django-backend/fecfiler/transactions/tests/test_views.py
@@ -233,6 +233,35 @@ class TransactionViewsTestCase(FecfilerViewSetTest):
             updated_transaction.children[0].schedule_b.expenditure_amount, 999
         )
 
+    def test_update_with_memo_text_of_other_committee_fails(self):
+        other_committee = CommitteeAccount.objects.create(committee_id="C00000001")
+        payload = deepcopy(self.payloads["IN_KIND"])
+        payload["memo_text"] = {
+            "fields_to_validate": ["rec_type", "report_id", "text4000"],
+            "text4000": "test memo",
+            "report_id": str(self.q1_report.id),
+            "rec_type": "TEXT",
+        }
+        response = self.send_viewset_post_request(
+            "/api/v1/transactions/",
+            payload,
+            TransactionViewSet,
+            "create",
+            committee=self.committee,
+        )
+        transaction = Transaction.objects.get(pk=response.data)
+        self.assertEqual(transaction.committee_account_id, self.committee.id)
+        updated_payload = deepcopy(self.payloads["IN_KIND"])
+        updated_payload["memo_text_id"] = transaction.memo_text.id
+        response = self.send_viewset_post_request(
+            "/api/v1/transactions/",
+            updated_payload,
+            TransactionViewSet,
+            "create",
+            committee=other_committee,
+        )
+        self.assertEqual(response.status_code, 400)
+
     def test_get_queryset(self):
         for i in range(8):
             create_schedule_a(

--- a/django-backend/fecfiler/transactions/views.py
+++ b/django-backend/fecfiler/transactions/views.py
@@ -474,7 +474,6 @@ class TransactionViewSet(CommitteeOwnedViewMixin, ModelViewSet):
 
     def save_transaction(self, transaction_data, request):
         committee_id = request.session["committee_uuid"]
-        report_ids = transaction_data.pop("report_ids", [])
         children = transaction_data.pop("children", [])
         schedule = transaction_data.get("schedule_id")
         transaction_data["parent_transaction"] = transaction_data.get(
@@ -551,6 +550,7 @@ class TransactionViewSet(CommitteeOwnedViewMixin, ModelViewSet):
         transaction_instance = transaction_serializer.save(**save_kwargs)
 
         # Link the transaction to all the reports it references in report_ids
+        report_ids = transaction_data.get("report_ids", [])
         transaction_instance.set_reports(report_ids)
 
         # handle loans and debts


### PR DESCRIPTION
Creates mixin to check if Report is in the same committee as the user's session and updates the Linked MemoText mixin to do the same for Memo Texts.
Added tests for both use cases.