### PR TITLE
[Hotfix] Respond with 403 when no committee is activated

### DIFF
--- a/django-backend/fecfiler/committee_accounts/serializers.py
+++ b/django-backend/fecfiler/committee_accounts/serializers.py
@@ -1,5 +1,5 @@
 from fecfiler.committee_accounts.models import CommitteeAccount, Membership
-from django.contrib.sessions.exceptions import SuspiciousSession
+from django.core.exceptions import PermissionDenied
 from rest_framework.relations import PrimaryKeyRelatedField
 from rest_framework.serializers import ModelSerializer, ChoiceField, SerializerMethodField
 from drf_spectacular.utils import extend_schema_field
@@ -32,10 +32,10 @@ class CommitteeOwnedSerializer(ModelSerializer):
 
     def get_committee_uuid(self):
         request = self.context["request"]
-        get_committee_uuid = request.session["committee_uuid"]
-        if not get_committee_uuid:
-            raise SuspiciousSession("session has invalid committee_uuid")
-        return get_committee_uuid
+        committee_uuid = request.session.get("committee_uuid")
+        if not committee_uuid:
+            raise PermissionDenied("You must activate a committee account")
+        return committee_uuid
 
 
 class CommitteeMembershipSerializer(CommitteeOwnedSerializer):

--- a/django-backend/fecfiler/committee_accounts/views.py
+++ b/django-backend/fecfiler/committee_accounts/views.py
@@ -1,7 +1,7 @@
 from uuid import UUID
 from .utils.committee_membership import add_user_to_committee
 from rest_framework import filters, viewsets, mixins, pagination, status
-from django.contrib.sessions.exceptions import SuspiciousSession
+from django.core.exceptions import PermissionDenied
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from fecfiler import settings
@@ -133,9 +133,9 @@ class CommitteeOwnedViewMixin(viewsets.GenericViewSet):
         return super().get_queryset().filter(committee_account_id=committee_uuid)
 
     def get_committee_uuid(self):
-        committee_uuid = self.request.session["committee_uuid"]
+        committee_uuid = self.request.session.get("committee_uuid")
         if not committee_uuid:
-            raise SuspiciousSession("session has invalid committee_uuid")
+            raise PermissionDenied("You must activate a committee account")
         return committee_uuid
 
     def list(self, request, *args, **kwargs):

--- a/django-backend/fecfiler/shared/viewset_test.py
+++ b/django-backend/fecfiler/shared/viewset_test.py
@@ -164,6 +164,6 @@ class FecfilerViewSetTest(TestCase):
                 committee if committee is not None else self.default_committee
             )
             request.session = {
-                "committee_uuid": str(request_committee.id),
-                "committee_id": str(request_committee.committee_id),
+                "committee_uuid": str(request_committee.id) if request_committee else None,
+                "committee_id": str(request_committee.committee_id) if request_committee else None,
             }

--- a/django-backend/fecfiler/shared/viewset_test.py
+++ b/django-backend/fecfiler/shared/viewset_test.py
@@ -164,6 +164,10 @@ class FecfilerViewSetTest(TestCase):
                 committee if committee is not None else self.default_committee
             )
             request.session = {
-                "committee_uuid": str(request_committee.id) if request_committee else None,
-                "committee_id": str(request_committee.committee_id) if request_committee else None,
+                "committee_uuid": (
+                    str(request_committee.id) if request_committee else None
+                ),
+                "committee_id": (
+                    str(request_committee.committee_id) if request_committee else None
+                ),
             }

--- a/django-backend/fecfiler/transactions/tests/test_views.py
+++ b/django-backend/fecfiler/transactions/tests/test_views.py
@@ -1157,6 +1157,17 @@ class TransactionViewsTestCase(FecfilerViewSetTest):
             "(See Partnership Attribution(s) below)",
         )
 
+    def test_transaction_lookup_no_committee_activated(self):
+        # User is authenticated but hasn't activated a committee
+        super().set_default_committee(None)
+        response = self.send_viewset_get_request(
+            "/api/v1/transactions/",
+            TransactionViewSet,
+            "list",
+            authenticate=True
+        )
+        self.assertEqual(response.status_code, 403)
+
     def test_loan_repayment_on_loan_by_committee(self):
         """Loan repayments should update loan balances on the original loan
         and on carried forward copies"""


### PR DESCRIPTION
Ticket link: https://fecgov.atlassian.net/browse/FOSEC-139

I confirmed my unit test catches the server error in the prior commits.
  
Example request to local (log in first, don't select a committee)
```
curl -X 'GET' \
  'http://localhost:8080/api/v1/reports/' \
  -H 'accept: application/json'
 ```

  **Before:** 500 error
  **After:** 403
  
