### PR TITLE
Hotfix - Unit test: transactions with another committee's child transactions

### DIFF
--- a/django-backend/fecfiler/transactions/tests/test_views.py
+++ b/django-backend/fecfiler/transactions/tests/test_views.py
@@ -262,6 +262,83 @@ class TransactionViewsTestCase(FecfilerViewSetTest):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_create_transaction_with_child_from_other_committee_fails(self):
+        other_committee = CommitteeAccount.objects.create(committee_id="C00000001")
+        other_report = create_form3x(other_committee, "2024-01-01", "2024-02-01", {})
+
+        other_payload = deepcopy(self.payloads["IN_KIND"])
+        other_payload["report_ids"] = [str(other_report.id)]
+        other_payload["children"][0]["report_ids"] = [str(other_report.id)]
+        response = self.send_viewset_post_request(
+            "/api/v1/transactions/",
+            other_payload,
+            TransactionViewSet,
+            "create",
+            committee=other_committee,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        foreign_child_id = str(Transaction.objects.get(pk=response.data).children[0].id)
+
+        payload = deepcopy(self.payloads["IN_KIND"])
+        payload["report_ids"] = [str(self.q1_report.id)]
+        payload["children"] = [foreign_child_id]
+
+        response = self.send_viewset_post_request(
+            "/api/v1/transactions/",
+            payload,
+            TransactionViewSet,
+            "create",
+            committee=self.committee,
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_update_transaction_with_child_from_other_committee_fails(self):
+        other_committee = CommitteeAccount.objects.create(committee_id="C00000002")
+        other_report = create_form3x(other_committee, "2024-01-01", "2024-02-01", {})
+
+        other_payload = deepcopy(self.payloads["IN_KIND"])
+        other_payload["report_ids"] = [str(other_report.id)]
+        other_payload["children"][0]["report_ids"] = [str(other_report.id)]
+        response = self.send_viewset_post_request(
+            "/api/v1/transactions/",
+            other_payload,
+            TransactionViewSet,
+            "create",
+            committee=other_committee,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        foreign_child_id = str(Transaction.objects.get(pk=response.data).children[0].id)
+
+        payload = deepcopy(self.payloads["IN_KIND"])
+        payload["report_ids"] = [str(self.q1_report.id)]
+        payload["children"][0]["report_ids"] = [str(self.q1_report.id)]
+        response = self.send_viewset_post_request(
+            "/api/v1/transactions/",
+            payload,
+            TransactionViewSet,
+            "create",
+            committee=self.committee,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        transaction = Transaction.objects.get(pk=response.data)
+
+        updated_payload = deepcopy(self.payloads["IN_KIND"])
+        updated_payload["id"] = str(transaction.id)
+        updated_payload["report_ids"] = [str(self.q1_report.id)]
+        updated_payload["children"] = [foreign_child_id]
+
+        response = self.send_viewset_put_request(
+            f"/api/v1/transactions/{transaction.id}/",
+            updated_payload,
+            TransactionViewSet,
+            "update",
+            committee=self.committee,
+        )
+        self.assertEqual(response.status_code, 400)
+
     def test_get_queryset(self):
         for i in range(8):
             create_schedule_a(

--- a/django-backend/fecfiler/utils.py
+++ b/django-backend/fecfiler/utils.py
@@ -23,13 +23,14 @@ def _safe_log_value(value):
         elif getattr(value, "args", None):
             value = value.args[0] if len(value.args) == 1 else value.args
 
-    if isinstance(value, (str, int, float, bool)):
-        return str(value)
+    # if isinstance(value, (str, int, float, bool)):
+    #     return str(value)
     if isinstance(value, (dict, list, tuple, set)):
         try:
             return json.dumps(value, default=str, sort_keys=True)
         except TypeError:
-            return str(value)
+            pass
+            # return str(value)
     return str(value)
 
 

--- a/django-backend/fecfiler/utils.py
+++ b/django-backend/fecfiler/utils.py
@@ -1,3 +1,5 @@
+import json
+
 from rest_framework.exceptions import ValidationError
 from django.http import HttpResponseServerError
 from fecfiler.oidc.utils import delete_user_logged_in_cookies
@@ -7,11 +9,52 @@ import structlog
 logger = structlog.get_logger(__name__)
 
 
+def _safe_log_value(value):
+    if value is None:
+        return "None"
+
+    if isinstance(value, BaseException):
+        detail = getattr(value, "detail", None)
+        if isinstance(detail, (dict, list, tuple, set)):
+            try:
+                return json.dumps(detail, default=str, sort_keys=True)
+            except TypeError:
+                return str(detail)
+        elif getattr(value, "args", None):
+            value = value.args[0] if len(value.args) == 1 else value.args
+
+    if isinstance(value, (str, int, float, bool)):
+        return str(value)
+    if isinstance(value, (dict, list, tuple, set)):
+        try:
+            return json.dumps(value, default=str, sort_keys=True)
+        except TypeError:
+            return str(value)
+    return str(value)
+
+
+def _is_safe_for_exception_logging(exc):
+    if not isinstance(exc, BaseException):
+        return False
+
+    detail = getattr(exc, "detail", None)
+    if isinstance(detail, (dict, list, tuple, set)):
+        return False
+
+    for arg in getattr(exc, "args", ()):
+        if isinstance(arg, (dict, list, tuple, set)):
+            return False
+
+    return True
+
+
 def custom_exception_handler(exc, context):
     # Call REST framework's default exception handler first,
     # to get the standard error response.
-
-    logger.exception(exc)
+    if _is_safe_for_exception_logging(exc):
+        logger.exception(_safe_log_value(exc), exc_info=False)
+    else:
+        logger.error("Exception: %s", _safe_log_value(exc))
     response = exception_handler(exc, context)
 
     if response is None:
@@ -28,7 +71,7 @@ def custom_exception_handler(exc, context):
     # Do not allow an error response body unless validation
     data = getattr(response, "data")
     exception_type = type(exc)
-    logger.error(f"Error: {data}")
+    logger.error("Error: %s", _safe_log_value(data))
     if data and exception_type is not ValidationError:
         response.data = None
 

--- a/django-backend/fecfiler/utils.py
+++ b/django-backend/fecfiler/utils.py
@@ -23,14 +23,11 @@ def _safe_log_value(value):
         elif getattr(value, "args", None):
             value = value.args[0] if len(value.args) == 1 else value.args
 
-    # if isinstance(value, (str, int, float, bool)):
-    #     return str(value)
     if isinstance(value, (dict, list, tuple, set)):
         try:
             return json.dumps(value, default=str, sort_keys=True)
         except TypeError:
             pass
-            # return str(value)
     return str(value)
 
 

--- a/django-backend/fecfiler/utils.py
+++ b/django-backend/fecfiler/utils.py
@@ -33,28 +33,10 @@ def _safe_log_value(value):
     return str(value)
 
 
-def _is_safe_for_exception_logging(exc):
-    if not isinstance(exc, BaseException):
-        return False
-
-    detail = getattr(exc, "detail", None)
-    if isinstance(detail, (dict, list, tuple, set)):
-        return False
-
-    for arg in getattr(exc, "args", ()):
-        if isinstance(arg, (dict, list, tuple, set)):
-            return False
-
-    return True
-
-
 def custom_exception_handler(exc, context):
     # Call REST framework's default exception handler first,
     # to get the standard error response.
-    if _is_safe_for_exception_logging(exc):
-        logger.exception(_safe_log_value(exc), exc_info=False)
-    else:
-        logger.error("Exception: %s", _safe_log_value(exc))
+    logger.exception(_safe_log_value(exc), exc_info=False)
     response = exception_handler(exc, context)
 
     if response is None:


### PR DESCRIPTION
Unit tests (-- currently failing by design --) checking that create and update of transactions are not allowed to include another committee's child transactions.

I also got tired of logger choking on exceptions so I modified `custom_exception_handler` to log them without errors.