### PR TITLE
Hotfix - fix transaction children

### DIFF
--- a/django-backend/fecfiler/transactions/tests/test_views.py
+++ b/django-backend/fecfiler/transactions/tests/test_views.py
@@ -262,6 +262,83 @@ class TransactionViewsTestCase(FecfilerViewSetTest):
         )
         self.assertEqual(response.status_code, 400)
 
+    def test_create_transaction_with_child_from_other_committee_fails(self):
+        other_committee = CommitteeAccount.objects.create(committee_id="C00000001")
+        other_report = create_form3x(other_committee, "2024-01-01", "2024-02-01", {})
+
+        other_payload = deepcopy(self.payloads["IN_KIND"])
+        other_payload["report_ids"] = [str(other_report.id)]
+        other_payload["children"][0]["report_ids"] = [str(other_report.id)]
+        response = self.send_viewset_post_request(
+            "/api/v1/transactions/",
+            other_payload,
+            TransactionViewSet,
+            "create",
+            committee=other_committee,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        foreign_child_id = str(Transaction.objects.get(pk=response.data).children[0].id)
+
+        payload = deepcopy(self.payloads["IN_KIND"])
+        payload["report_ids"] = [str(self.q1_report.id)]
+        payload["children"] = [foreign_child_id]
+
+        response = self.send_viewset_post_request(
+            "/api/v1/transactions/",
+            payload,
+            TransactionViewSet,
+            "create",
+            committee=self.committee,
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_update_transaction_with_child_from_other_committee_fails(self):
+        other_committee = CommitteeAccount.objects.create(committee_id="C00000002")
+        other_report = create_form3x(other_committee, "2024-01-01", "2024-02-01", {})
+
+        other_payload = deepcopy(self.payloads["IN_KIND"])
+        other_payload["report_ids"] = [str(other_report.id)]
+        other_payload["children"][0]["report_ids"] = [str(other_report.id)]
+        response = self.send_viewset_post_request(
+            "/api/v1/transactions/",
+            other_payload,
+            TransactionViewSet,
+            "create",
+            committee=other_committee,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        foreign_child_id = str(Transaction.objects.get(pk=response.data).children[0].id)
+
+        payload = deepcopy(self.payloads["IN_KIND"])
+        payload["report_ids"] = [str(self.q1_report.id)]
+        payload["children"][0]["report_ids"] = [str(self.q1_report.id)]
+        response = self.send_viewset_post_request(
+            "/api/v1/transactions/",
+            payload,
+            TransactionViewSet,
+            "create",
+            committee=self.committee,
+        )
+        self.assertEqual(response.status_code, 200)
+
+        transaction = Transaction.objects.get(pk=response.data)
+
+        updated_payload = deepcopy(self.payloads["IN_KIND"])
+        updated_payload["id"] = str(transaction.id)
+        updated_payload["report_ids"] = [str(self.q1_report.id)]
+        updated_payload["children"] = [foreign_child_id]
+
+        response = self.send_viewset_put_request(
+            f"/api/v1/transactions/{transaction.id}/",
+            updated_payload,
+            TransactionViewSet,
+            "update",
+            committee=self.committee,
+        )
+        self.assertEqual(response.status_code, 400)
+
     def test_get_queryset(self):
         for i in range(8):
             create_schedule_a(

--- a/django-backend/fecfiler/transactions/tests/test_views.py
+++ b/django-backend/fecfiler/transactions/tests/test_views.py
@@ -342,6 +342,7 @@ class TransactionViewsTestCase(FecfilerViewSetTest):
             updated_payload,
             TransactionViewSet,
             "update",
+            pk=transaction.id,
             committee=self.committee,
         )
         self.assertEqual(response.status_code, 400)

--- a/django-backend/fecfiler/transactions/views.py
+++ b/django-backend/fecfiler/transactions/views.py
@@ -484,7 +484,7 @@ class TransactionViewSet(CommitteeOwnedViewMixin, ModelViewSet):
         ).filter(id=child_id, committee_account_id=committee_id).first()
         if child_instance is None:
             raise ValidationError(
-                {"children": ["Invalid child_id or child does not belong."]}
+                {"children": ["Invalid child_id or child"]}
             )
         return child_instance
 

--- a/django-backend/fecfiler/transactions/views.py
+++ b/django-backend/fecfiler/transactions/views.py
@@ -5,6 +5,7 @@ from rest_framework.filters import OrderingFilter
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.exceptions import ValidationError
 from rest_framework.viewsets import ModelViewSet
 from datetime import datetime
 from django.db.models import Q
@@ -472,6 +473,17 @@ class TransactionViewSet(CommitteeOwnedViewMixin, ModelViewSet):
             ):
                 target.schedule_f.aggregate_general_elec_expended -= amount
 
+    def get_child_instance(self, child_id, committee_id):
+        # ensure that child transaction belongs to this committee
+        child_instance = Transaction.objects.select_related(
+            "schedule_a", "schedule_b", "schedule_e", "contact_2"
+        ).filter(id=child_id, committee_account_id=committee_id).first()
+        if child_instance is None:
+            raise ValidationError(
+                {"children": ["Child transaction does not belong to this committee."]}
+            )
+        return child_instance
+
     def save_transaction(self, transaction_data, request):
         committee_id = request.session["committee_uuid"]
         children = transaction_data.pop("children", [])
@@ -591,39 +603,39 @@ class TransactionViewSet(CommitteeOwnedViewMixin, ModelViewSet):
 
         for child_transaction_data in children:
             if type(child_transaction_data) is str:
+                child_id = child_transaction_data
+                child_instance = self.get_child_instance(child_id, committee_id)
+
                 # Capture old state BEFORE updating
-                try:
-                    child_instance = Transaction.objects.select_related(
-                        "schedule_a", "schedule_b", "schedule_e", "contact_2"
-                    ).get(id=child_transaction_data)
+                old_snapshot = None
+                if child_instance.get_schedule_name() in [
+                    Schedule.A,
+                    Schedule.B,
+                    Schedule.E,
+                ]:
+                    eff = calculate_effective_amount(child_instance)
+                    old_snapshot = create_old_snapshot(child_instance, eff)
 
-                    # Capture old snapshot if this is an aggregating schedule
-                    old_snapshot = None
-                    if child_instance.get_schedule_name() in [
-                        Schedule.A,
-                        Schedule.B,
-                        Schedule.E,
-                    ]:
-                        eff = calculate_effective_amount(child_instance)
-                        old_snapshot = create_old_snapshot(child_instance, eff)
+                # Update parent and skip aggregation during save
+                child_instance.parent_transaction_id = transaction_instance.id
+                child_instance._skip_aggregation = True
+                if old_snapshot:
+                    child_instance._passed_old_snapshot = old_snapshot
+                child_instance.save()
 
-                    # Update parent and skip aggregation during save
-                    child_instance.parent_transaction_id = transaction_instance.id
-                    child_instance._skip_aggregation = True
-                    if old_snapshot:
-                        child_instance._passed_old_snapshot = old_snapshot
-                    child_instance.save()
-
-                    # Track child for post-save aggregation
-                    if child_instance.get_schedule_name() in [
-                        Schedule.A,
-                        Schedule.B,
-                        Schedule.E,
-                    ]:
-                        child_instances_to_aggregate.append(child_instance)
-                except Transaction.DoesNotExist:
-                    pass
+                # Track child for post-save aggregation
+                if child_instance.get_schedule_name() in [
+                    Schedule.A,
+                    Schedule.B,
+                    Schedule.E,
+                ]:
+                    child_instances_to_aggregate.append(child_instance)
             else:
+                child_id = child_transaction_data.get("id")
+                if child_id:
+                    # we don't need the instance but want to check that it belongs to this committee
+                    child_instance = self.get_child_instance(child_id, committee_id)
+
                 child_transaction_data["parent_transaction_id"] = transaction_instance.id
                 child_transaction_data.pop("parent_transaction", None)
                 if child_transaction_data.get("use_parent_contact", None):

--- a/django-backend/fecfiler/transactions/views.py
+++ b/django-backend/fecfiler/transactions/views.py
@@ -484,7 +484,7 @@ class TransactionViewSet(CommitteeOwnedViewMixin, ModelViewSet):
         ).filter(id=child_id, committee_account_id=committee_id).first()
         if child_instance is None:
             raise ValidationError(
-                {"children": ["Child transaction does not belong to this committee."]}
+                {"children": ["Invalid child_id or child does not belong."]}
             )
         return child_instance
 

--- a/django-backend/fecfiler/transactions/views.py
+++ b/django-backend/fecfiler/transactions/views.py
@@ -633,8 +633,8 @@ class TransactionViewSet(CommitteeOwnedViewMixin, ModelViewSet):
             else:
                 child_id = child_transaction_data.get("id")
                 if child_id:
-                    # we don't need the instance 
-                    # but want to check that it belongs to this committee
+                    # we don't need the instance but...
+                    # we do want to check that it belongs to this committee
                     child_instance = self.get_child_instance(child_id, committee_id)
 
                 child_transaction_data["parent_transaction_id"] = transaction_instance.id

--- a/django-backend/fecfiler/transactions/views.py
+++ b/django-backend/fecfiler/transactions/views.py
@@ -633,9 +633,8 @@ class TransactionViewSet(CommitteeOwnedViewMixin, ModelViewSet):
             else:
                 child_id = child_transaction_data.get("id")
                 if child_id:
-                    # we don't need the instance but...
-                    # we do want to check that it belongs to this committee
-                    child_instance = self.get_child_instance(child_id, committee_id)
+                    # check that it belongs to this committee
+                    self.get_child_instance(child_id, committee_id)
 
                 child_transaction_data["parent_transaction_id"] = transaction_instance.id
                 child_transaction_data.pop("parent_transaction", None)

--- a/django-backend/fecfiler/transactions/views.py
+++ b/django-backend/fecfiler/transactions/views.py
@@ -633,7 +633,8 @@ class TransactionViewSet(CommitteeOwnedViewMixin, ModelViewSet):
             else:
                 child_id = child_transaction_data.get("id")
                 if child_id:
-                    # we don't need the instance but want to check that it belongs to this committee
+                    # we don't need the instance 
+                    # but want to check that it belongs to this committee
                     child_instance = self.get_child_instance(child_id, committee_id)
 
                 child_transaction_data["parent_transaction_id"] = transaction_instance.id

--- a/django-backend/fecfiler/utils.py
+++ b/django-backend/fecfiler/utils.py
@@ -23,13 +23,14 @@ def _safe_log_value(value):
         elif getattr(value, "args", None):
             value = value.args[0] if len(value.args) == 1 else value.args
 
-    if isinstance(value, (str, int, float, bool)):
-        return str(value)
+    # if isinstance(value, (str, int, float, bool)):
+    #     return str(value)
     if isinstance(value, (dict, list, tuple, set)):
         try:
             return json.dumps(value, default=str, sort_keys=True)
         except TypeError:
-            return str(value)
+            pass
+            # return str(value)
     return str(value)
 
 

--- a/django-backend/fecfiler/utils.py
+++ b/django-backend/fecfiler/utils.py
@@ -1,3 +1,5 @@
+import json
+
 from rest_framework.exceptions import ValidationError
 from django.http import HttpResponseServerError
 from fecfiler.oidc.utils import delete_user_logged_in_cookies
@@ -7,11 +9,52 @@ import structlog
 logger = structlog.get_logger(__name__)
 
 
+def _safe_log_value(value):
+    if value is None:
+        return "None"
+
+    if isinstance(value, BaseException):
+        detail = getattr(value, "detail", None)
+        if isinstance(detail, (dict, list, tuple, set)):
+            try:
+                return json.dumps(detail, default=str, sort_keys=True)
+            except TypeError:
+                return str(detail)
+        elif getattr(value, "args", None):
+            value = value.args[0] if len(value.args) == 1 else value.args
+
+    if isinstance(value, (str, int, float, bool)):
+        return str(value)
+    if isinstance(value, (dict, list, tuple, set)):
+        try:
+            return json.dumps(value, default=str, sort_keys=True)
+        except TypeError:
+            return str(value)
+    return str(value)
+
+
+def _is_safe_for_exception_logging(exc):
+    if not isinstance(exc, BaseException):
+        return False
+
+    detail = getattr(exc, "detail", None)
+    if isinstance(detail, (dict, list, tuple, set)):
+        return False
+
+    for arg in getattr(exc, "args", ()):
+        if isinstance(arg, (dict, list, tuple, set)):
+            return False
+
+    return True
+
+
 def custom_exception_handler(exc, context):
     # Call REST framework's default exception handler first,
     # to get the standard error response.
-
-    logger.exception(exc)
+    if _is_safe_for_exception_logging(exc):
+        logger.exception(_safe_log_value(exc), exc_info=False)
+    else:
+        logger.error("Exception: %s", _safe_log_value(exc))
     response = exception_handler(exc, context)
 
     if response is None:
@@ -28,7 +71,7 @@ def custom_exception_handler(exc, context):
     # Do not allow an error response body unless validation
     data = getattr(response, "data")
     exception_type = type(exc)
-    logger.error(f"Error: {data}")
+    logger.error("Error: %s", _safe_log_value(data))
     if data and exception_type is not ValidationError:
         response.data = None
 

--- a/django-backend/fecfiler/utils.py
+++ b/django-backend/fecfiler/utils.py
@@ -23,14 +23,11 @@ def _safe_log_value(value):
         elif getattr(value, "args", None):
             value = value.args[0] if len(value.args) == 1 else value.args
 
-    # if isinstance(value, (str, int, float, bool)):
-    #     return str(value)
     if isinstance(value, (dict, list, tuple, set)):
         try:
             return json.dumps(value, default=str, sort_keys=True)
         except TypeError:
             pass
-            # return str(value)
     return str(value)
 
 

--- a/django-backend/fecfiler/utils.py
+++ b/django-backend/fecfiler/utils.py
@@ -33,28 +33,10 @@ def _safe_log_value(value):
     return str(value)
 
 
-def _is_safe_for_exception_logging(exc):
-    if not isinstance(exc, BaseException):
-        return False
-
-    detail = getattr(exc, "detail", None)
-    if isinstance(detail, (dict, list, tuple, set)):
-        return False
-
-    for arg in getattr(exc, "args", ()):
-        if isinstance(arg, (dict, list, tuple, set)):
-            return False
-
-    return True
-
-
 def custom_exception_handler(exc, context):
     # Call REST framework's default exception handler first,
     # to get the standard error response.
-    if _is_safe_for_exception_logging(exc):
-        logger.exception(_safe_log_value(exc), exc_info=False)
-    else:
-        logger.error("Exception: %s", _safe_log_value(exc))
+    logger.exception(_safe_log_value(exc), exc_info=False)
     response = exception_handler(exc, context)
 
     if response is None:


### PR DESCRIPTION
Don't create or update a transaction with child transactions belonging to another committee.

After this change the new unit tests added in the related PR pass.

Related PRs:
https://github.com/fecgov/fecfile-web-api/pull/2235 (also included in this PR)

# Manual Reproduction

## In brief
* have a Committee A and a Committee B
* create a valid transaction under Committee B
* grab the child ID from that new transaction
* submit a new/create or update request under Committee A that includes that foreign child ID in `children`
* API should reject it with HTTP 400

## More verbose

### Prepare two committees and reports
In the app, or in test data, create:
* Committee A
* Committee B
* one report in Committee A
* one report in Committee B

### Create a valid child transaction in Committee B
* Open the Network tab of Developer Tools
* Create a normal transaction that has a child.
* Grab that API call as curl

### Create the malicious payload in Committee A
* Switch to Committee A and open the create transaction form.
* Maybe create a transaction there just to grab the API call and get the ID of Committee B
* Modify the API call to replace the `children` with the foreign child ID from Committee B

### Submit it
It should return an HTTP 400