### PR TITLE
FECFILE-3346: Update gitpython to 3.1.58

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ drf-spectacular-sidecar==2026.4.14
 Faker==37.6.0
 git+https://github.com/fecgov/fecfile-validate@8384e8c2747e64ebacd85031dcb9d214cfa513c5#egg=fecfile_validate&subdirectory=fecfile_validate_python
 github3.py==4.0.1
-GitPython==3.1.55
+GitPython==3.1.58
 gunicorn==23.0.0
 invoke==2.2.0
 jwcrypto==1.5.7


### PR DESCRIPTION
Ticket link:
https://fecgov.atlassian.net/browse/FECFILE-3346

Related PRs:
N/A